### PR TITLE
Add support for XML and HTML output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.gradle
+build/
+
+.idea/
+*.iml
+out/
+
+.poject
+.settings
+.classpath

--- a/README.adoc
+++ b/README.adoc
@@ -42,6 +42,7 @@ packagesToExclude:: List of package names to exclude, * can be used as wildcard.
 accessModifier:: Sets the access modifier level (public, package, protected, private). Type: _String_. Default value: _public_
 failOnModification:: When set to true, the build fails in case a modification has been detected. Type: _boolean_. Default value: _false_
 xmlOutputFile:: Path to the generated XML report. Type: _File_. Default value: _null_
+htmlOutputFile:: Path to the generated HTML report (requires `xmlOutputFile` to be set). Type: _File_. Default value: _null_
 txtOutputFile:: Path to the generated TXT report. Type: _File_. Default value: _null_
 
 == Usage

--- a/src/main/groovy/me/champeau/gradle/JapicmpAbstractTask.groovy
+++ b/src/main/groovy/me/champeau/gradle/JapicmpAbstractTask.groovy
@@ -15,6 +15,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.Optional
+import com.google.common.base.Optional as GOptional
 
 abstract class JapicmpAbstractTask extends AbstractTask {
     private final static Closure<Boolean> DEFAULT_BREAK_BUILD_CHECK = { it.changeStatus != JApiChangeStatus.UNCHANGED }
@@ -33,7 +34,6 @@ abstract class JapicmpAbstractTask extends AbstractTask {
     
     @Input
     @Optional 
-    
     boolean onlyModified = false
     
     @OutputFile
@@ -41,7 +41,12 @@ abstract class JapicmpAbstractTask extends AbstractTask {
     File xmlOutputFile
 
     @OutputFile
-    @Optional File txtOutputFile
+    @Optional
+    File txtOutputFile
+
+    @OutputFile
+    @Optional
+    File htmlOutputFile
 
     @Input
     @Optional
@@ -93,9 +98,11 @@ abstract class JapicmpAbstractTask extends AbstractTask {
         def options = new Options()
         options.outputOnlyModifications = onlyModified
         options.setAccessModifier(AccessModifier.valueOf(accessModifier.toUpperCase()))
+        options.htmlOutputFile = GOptional.fromNullable(htmlOutputFile?.absolutePath)
         if (xmlOutputFile) {
+            options.xmlOutputFile = GOptional.of(xmlOutputFile.absolutePath)
             def xmlOutputGenerator = new XmlOutputGenerator()
-            xmlOutputGenerator.generate(getOldArchive(), getNewArchive(), jApiClasses, options)
+            xmlOutputGenerator.generate(getOldArchive().absolutePath, getNewArchive().absolutePath, jApiClasses, options)
         }
         if (txtOutputFile) {
             StdoutOutputGenerator stdoutOutputGenerator = new StdoutOutputGenerator(options)


### PR DESCRIPTION
Due to implementation in japicmp XML output file has to be set for HTML output file to be generated.