### PR TITLE
Upgrade to japicmp 0.7.2, add switches for HTML output and binary incompatibility report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.nb-gradle/
+.gradle/
+/build/

--- a/README.adoc
+++ b/README.adoc
@@ -37,11 +37,13 @@ exposes the following properties as part of its configuration:
 oldArchive:: The jar file which will be used as the reference for comparison. Type: _File_.
 newArchive:: The jar file we want the report to work on. Type: _File_.
 onlyModified:: Outputs only modified classes/methods. If not set to true, all classes and methods are printed. Type: _boolean_. Default value: _false_
+onlyBinaryIncompatibleModified:: Outputs only classes/methods with modifications that result in binary incompatibility. Type: _boolean_. Default value: _false_
 packagesToInclude:: List of package names to include, * can be used as wildcard. Type: _List<String>_
 packagesToExclude:: List of package names to exclude, * can be used as wildcard. Type: _List<String>_
 accessModifier:: Sets the access modifier level (public, package, protected, private). Type: _String_. Default value: _public_
 failOnModification:: When set to true, the build fails in case a modification has been detected. Type: _boolean_. Default value: _false_
 xmlOutputFile:: Path to the generated XML report. Type: _File_. Default value: _null_
+htmlOutputFile:: Path to the generated HTML report. Type: _File_. Default value: _null_
 txtOutputFile:: Path to the generated TXT report. Type: _File_. Default value: _null_
 includeSynthetic:: Synthetic classes and class members (like e.g. bridge methods) are not tracked per default. This new option enables the tracking of such kind of classes and class members
 

--- a/gradle/compile.gradle
+++ b/gradle/compile.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.github.siom79.japicmp:japicmp:0.5.0') {
+    compile('com.github.siom79.japicmp:japicmp:0.7.2') {
         exclude group:'com.google.guava'
         exclude group:'io.airlift'
     }

--- a/src/main/groovy/me/champeau/gradle/JapicmpAbstractTask.groovy
+++ b/src/main/groovy/me/champeau/gradle/JapicmpAbstractTask.groovy
@@ -37,9 +37,17 @@ abstract class JapicmpAbstractTask extends AbstractTask {
     @Optional
     boolean onlyModified = false
 
+    @Input
+    @Optional
+    boolean onlyBinaryIncompatibleModified = false
+
     @OutputFile
     @Optional
     File xmlOutputFile
+
+    @OutputFile
+    @Optional
+    File htmlOutputFile
 
     @OutputFile
     @Optional File txtOutputFile
@@ -100,10 +108,16 @@ abstract class JapicmpAbstractTask extends AbstractTask {
         options.oldArchives.add(getOldArchive())
         options.newArchives.add(getNewArchive())
         options.outputOnlyModifications = onlyModified
+        options.outputOnlyBinaryIncompatibleModifications = onlyBinaryIncompatibleModified
         options.includeSynthetic = includeSynthetic
         options.setAccessModifier(AccessModifier.valueOf(accessModifier.toUpperCase()))
         if (xmlOutputFile) {
             options.xmlOutputFile = com.google.common.base.Optional.of(xmlOutputFile.getAbsolutePath())
+        }
+        if (htmlOutputFile) {
+            options.htmlOutputFile = com.google.common.base.Optional.of(htmlOutputFile.getAbsolutePath())
+        }
+        if (xmlOutputFile || htmlOutputFile) {
             def xmlOptions = new XmlOutputGeneratorOptions()
             def xmlOutputGenerator = new XmlOutputGenerator(jApiClasses, options, xmlOptions)
             XmlOutput xmlOutput = xmlOutputGenerator.generate()

--- a/src/main/groovy/me/champeau/gradle/JapicmpAbstractTask.groovy
+++ b/src/main/groovy/me/champeau/gradle/JapicmpAbstractTask.groovy
@@ -3,12 +3,14 @@ package me.champeau.gradle
 import japicmp.cmp.JarArchiveComparator
 import japicmp.cmp.JarArchiveComparatorOptions
 import japicmp.config.Options
-import japicmp.filter.PackageFilter
+import japicmp.filter.JavadocLikePackageFilter
 import japicmp.model.AccessModifier
 import japicmp.model.JApiChangeStatus
 import japicmp.model.JApiClass
 import japicmp.output.stdout.StdoutOutputGenerator
+import japicmp.output.xml.XmlOutput
 import japicmp.output.xml.XmlOutputGenerator
+import japicmp.output.xml.XmlOutputGeneratorOptions
 import org.gradle.api.GradleException
 import org.gradle.api.internal.AbstractTask
 import org.gradle.api.tasks.Input
@@ -80,8 +82,8 @@ abstract class JapicmpAbstractTask extends AbstractTask {
         def options = new JarArchiveComparatorOptions()
         options.includeSynthetic = includeSynthetic
         options.with {
-            packagesInclude.addAll(packageIncludes.collect { new PackageFilter(it) })
-            packagesExclude.addAll(packageExcludes.collect { new PackageFilter(it) })
+            filters.getIncludes().addAll(packageIncludes.collect { new JavadocLikePackageFilter(it) })
+            filters.getExcludes().addAll(packageExcludes.collect { new JavadocLikePackageFilter(it) })
             Collection<File> files = classpath ?: project.configurations.japicmp.files
             files.each {
                 if (it.exists()) {
@@ -95,16 +97,21 @@ abstract class JapicmpAbstractTask extends AbstractTask {
     private void generateOutput(final List<JApiClass> jApiClasses) {
         // we create a dummy options because we don't want to avoid use of internal classes of JApicmp
         def options = new Options()
+        options.oldArchives.add(getOldArchive())
+        options.newArchives.add(getNewArchive())
         options.outputOnlyModifications = onlyModified
         options.includeSynthetic = includeSynthetic
         options.setAccessModifier(AccessModifier.valueOf(accessModifier.toUpperCase()))
         if (xmlOutputFile) {
-            def xmlOutputGenerator = new XmlOutputGenerator()
-            xmlOutputGenerator.generate(getOldArchive(), getNewArchive(), jApiClasses, options)
+            options.xmlOutputFile = com.google.common.base.Optional.of(xmlOutputFile.getAbsolutePath())
+            def xmlOptions = new XmlOutputGeneratorOptions()
+            def xmlOutputGenerator = new XmlOutputGenerator(jApiClasses, options, xmlOptions)
+            XmlOutput xmlOutput = xmlOutputGenerator.generate()
+            XmlOutputGenerator.writeToFiles(options, xmlOutput)
         }
         if (txtOutputFile) {
-            StdoutOutputGenerator stdoutOutputGenerator = new StdoutOutputGenerator(options)
-            String output = stdoutOutputGenerator.generate(getOldArchive(), getNewArchive(), jApiClasses)
+            StdoutOutputGenerator stdoutOutputGenerator = new StdoutOutputGenerator(options, jApiClasses)
+            String output = stdoutOutputGenerator.generate()
             txtOutputFile.write(output)
         }
         def generic = new GenericOutputProcessor(


### PR DESCRIPTION
These changes upgrade japicmp to 0.7.2 and add switches for enabling HTML output and for reporting binary incompatible changes only.