### PR TITLE
Add option to break build if source incompatibile changes detected

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -56,6 +56,7 @@ onlyBinaryIncompatibleModified:: Outputs only classes/methods with modifications
 packageIncludes:: List of package names to include, * can be used as wildcard. Type: _List<String>_
 packageExcludes:: List of package names to exclude, * can be used as wildcard. Type: _List<String>_
 accessModifier:: Sets the access modifier level (public, package, protected, private). Type: _String_. Default value: _public_
+failOnSourceIncompatibility:: Fails if the changes result in source level incompatibility. Setting this to `true` also implicitly enables `failOnModification`. imType: _boolean_. Default value: _false_
 failOnModification:: When set to true, the build fails in case a modification has been detected. Type: _boolean_. Default value: _false_
 xmlOutputFile:: Path to the generated XML report. Type: _File_. Default value: _null_
 htmlOutputFile:: Path to the generated HTML report. Type: _File_. Default value: _null_

--- a/src/main/java/me/champeau/gradle/japicmp/JApiCmpWorkerAction.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JApiCmpWorkerAction.java
@@ -69,6 +69,7 @@ public class JApiCmpWorkerAction extends JapiCmpWorkerConfiguration implements R
                 configuration.newArchives,
                 configuration.onlyModified,
                 configuration.onlyBinaryIncompatibleModified,
+                configuration.failOnSourceIncompatibility,
                 configuration.accessModifier,
                 configuration.xmlOutputFile,
                 configuration.htmlOutputFile,
@@ -231,7 +232,7 @@ public class JApiCmpWorkerAction extends JapiCmpWorkerConfiguration implements R
         }
 
 
-        if ((failOnModification && hasBreakingChange(jApiClasses)) || hasCustomViolations) {
+        if ((failOnModification && hasBreakingChange(jApiClasses, failOnSourceIncompatibility)) || hasCustomViolations) {
             String reportLink;
             try {
                 reportLink = reportFile != null ? new URI("file", "", reportFile.toURI().getPath(), null, null).toString() : null;
@@ -249,9 +250,9 @@ public class JApiCmpWorkerAction extends JapiCmpWorkerConfiguration implements R
         }
     }
 
-    private static boolean hasBreakingChange(final List<JApiClass> jApiClasses) {
+    private static boolean hasBreakingChange(final List<JApiClass> jApiClasses, final boolean failOnSourceIncompatibility) {
         for (JApiClass jApiClass : jApiClasses) {
-            if (!jApiClass.isBinaryCompatible()) {
+            if (!jApiClass.isBinaryCompatible() || (failOnSourceIncompatibility && !jApiClass.isSourceCompatible())) {
                 return true;
             }
         }

--- a/src/main/java/me/champeau/gradle/japicmp/JapiCmpWorkerConfiguration.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JapiCmpWorkerConfiguration.java
@@ -32,6 +32,7 @@ public class JapiCmpWorkerConfiguration implements Serializable {
     protected final List<JApiCmpWorkerAction.Archive> newArchives;
     protected final boolean onlyModified;
     protected final boolean onlyBinaryIncompatibleModified;
+    protected final boolean failOnSourceIncompatibility;
     protected final String accessModifier;
     protected final File xmlOutputFile;
     protected final File htmlOutputFile;
@@ -50,6 +51,7 @@ public class JapiCmpWorkerConfiguration implements Serializable {
                                       final List<JApiCmpWorkerAction.Archive> newArchives,
                                       final boolean onlyModified,
                                       final boolean onlyBinaryIncompatibleModified,
+                                      final boolean failOnSourceIncompatibility,
                                       final String accessModifier,
                                       final File xmlOutputFile,
                                       final File htmlOutputFile,
@@ -67,11 +69,12 @@ public class JapiCmpWorkerConfiguration implements Serializable {
         this.newArchives = newArchives;
         this.onlyModified = onlyModified;
         this.onlyBinaryIncompatibleModified = onlyBinaryIncompatibleModified;
+        this.failOnSourceIncompatibility = failOnSourceIncompatibility;
         this.accessModifier = accessModifier;
         this.xmlOutputFile = xmlOutputFile;
         this.htmlOutputFile = htmlOutputFile;
         this.txtOutputFile = txtOutputFile;
-        this.failOnModification = failOnModification;
+        this.failOnModification = failOnModification | failOnSourceIncompatibility;
         this.buildDir = buildDir;
         this.richReport = richReport;
     }

--- a/src/main/java/me/champeau/gradle/japicmp/JapicmpTask.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JapicmpTask.java
@@ -35,6 +35,7 @@ public class JapicmpTask extends DefaultTask {
     private String accessModifier = "public";
     private boolean onlyModified = false;
     private boolean onlyBinaryIncompatibleModified = false;
+    private boolean failOnSourceIncompatibility = false;
     private File xmlOutputFile;
     private File htmlOutputFile;
     private File txtOutputFile;
@@ -86,6 +87,7 @@ public class JapicmpTask extends DefaultTask {
                                 current,
                                 getOnlyModified(),
                                 getOnlyBinaryIncompatibleModified(),
+                                getFailOnSourceIncompatibility(),
                                 getAccessModifier(),
                                 getXmlOutputFile(),
                                 getHtmlOutputFile(),
@@ -194,6 +196,16 @@ public class JapicmpTask extends DefaultTask {
 
     public void setOnlyBinaryIncompatibleModified(boolean onlyBinaryIncompatibleModified) {
         this.onlyBinaryIncompatibleModified = onlyBinaryIncompatibleModified;
+    }
+
+    @Input
+    @Optional
+    public boolean getFailOnSourceIncompatibility() {
+        return failOnSourceIncompatibility;
+    }
+
+    public void setFailOnSourceIncompatibility(boolean failOnSourceIncompatibility) {
+        this.failOnSourceIncompatibility = failOnSourceIncompatibility;
     }
 
     @OutputFile

--- a/src/test/groovy/me/champeau/gradle/SourceIncompatibleChange.groovy
+++ b/src/test/groovy/me/champeau/gradle/SourceIncompatibleChange.groovy
@@ -1,0 +1,31 @@
+package me.champeau.gradle
+
+import org.gradle.testkit.runner.TaskOutcome
+
+class SourceIncompatibleChangeTest extends BaseFunctionalTest {
+    String testProject = 'source-incompatible-change'
+
+    def "source incompatibility does not break build by default"() {
+        when:
+        def result = run "japicmpIgnoresSourceCompatabilityByDefault"
+
+        then:
+        result.task(":japicmpIgnoresSourceCompatabilityByDefault").outcome == TaskOutcome.SUCCESS
+    }
+
+    def "source incompatibility breaks build"() {
+        when:
+        def result = fails "japicmpFailsOnSourceIncompatability"
+
+        then:
+        result.task(":japicmpFailsOnSourceIncompatability").outcome == TaskOutcome.FAILED
+    }
+
+    def "source incompatibility breaks build (non-public access)"() {
+        when:
+        def result = fails "japicmpFailsOnSourceIncompatabilityNonPublic"
+
+        then:
+        result.task(":japicmpFailsOnSourceIncompatabilityNonPublic").outcome == TaskOutcome.FAILED
+    }
+}

--- a/src/test/test-projects/source-incompatible-change/build.gradle
+++ b/src/test/test-projects/source-incompatible-change/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'java'
+    id 'me.champeau.gradle.japicmp'
+}
+
+sourceSets {
+    main2
+}
+
+task jarv2(type:Jar) {
+    classifier = 'v2'
+    from sourceSets.main2.output
+}
+
+task japicmpIgnoresSourceCompatabilityByDefault(type: me.champeau.gradle.japicmp.JapicmpTask) {
+    dependsOn jar, jarv2
+    oldClasspath = files(jar.archivePath)
+    newClasspath = files(jarv2.archivePath)
+    failOnModification = true
+}
+
+task japicmpFailsOnSourceIncompatability(type: me.champeau.gradle.japicmp.JapicmpTask) {
+    dependsOn jar, jarv2
+    oldClasspath = files(jar.archivePath)
+    newClasspath = files(jarv2.archivePath)
+    failOnSourceIncompatibility = true
+    packageExcludes = ['me.champeau.gradle.japicmp.internal']
+}
+
+task japicmpFailsOnSourceIncompatabilityNonPublic(type: me.champeau.gradle.japicmp.JapicmpTask) {
+    dependsOn jar, jarv2
+    oldClasspath = files(jar.archivePath)
+    newClasspath = files(jarv2.archivePath)
+    failOnSourceIncompatibility = true
+    packageExcludes = ['me.champeau.gradle.japicmp']
+    accessModifier = 'package-private'
+}

--- a/src/test/test-projects/source-incompatible-change/src/main/java/ExternalClass.java
+++ b/src/test/test-projects/source-incompatible-change/src/main/java/ExternalClass.java
@@ -1,0 +1,3 @@
+package me.champeau.gradle.japicmp;
+
+public abstract class ExternalClass {}

--- a/src/test/test-projects/source-incompatible-change/src/main/java/InternalClass.java
+++ b/src/test/test-projects/source-incompatible-change/src/main/java/InternalClass.java
@@ -1,0 +1,3 @@
+package me.champeau.gradle.japicmp.internal;
+
+public abstract class InternalClass {}

--- a/src/test/test-projects/source-incompatible-change/src/main2/java/ExternalClass.java
+++ b/src/test/test-projects/source-incompatible-change/src/main2/java/ExternalClass.java
@@ -1,0 +1,6 @@
+package me.champeau.gradle.japicmp;
+
+public abstract class ExternalClass {
+    /** Adding a new abstract method breaks existing implementations. */
+    public abstract void breakingChange();
+}

--- a/src/test/test-projects/source-incompatible-change/src/main2/java/InternalClass.java
+++ b/src/test/test-projects/source-incompatible-change/src/main2/java/InternalClass.java
@@ -1,0 +1,6 @@
+package me.champeau.gradle.japicmp.internal;
+
+public abstract class InternalClass {
+    /** Adding a new abstract method breaks existing implementations. */
+    abstract void breakingChange();
+}


### PR DESCRIPTION
It looks like japicmp itself has this option, and it's just not
plumbed though the gradle plugin. Without this, the plugin would
not detect when someone adds a new abstract method to a public
class, which results in breaking pre-existing subclasses.
