### PR TITLE
Make it clear which tool is failing from build error message

### DIFF
--- a/src/main/java/me/champeau/gradle/japicmp/JapicmpTask.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JapicmpTask.java
@@ -92,7 +92,7 @@ public class JapicmpTask extends DefaultTask {
                 workerConfiguration.setClasspath(classpath);
                 List<JApiCmpWorkerAction.Archive> baseline = JapicmpTask.this.oldArchives != null ? toArchives(JapicmpTask.this.oldArchives) : inferArchives(oldClasspath);
                 List<JApiCmpWorkerAction.Archive> current = JapicmpTask.this.newArchives != null ? toArchives(JapicmpTask.this.newArchives) : inferArchives(newClasspath);
-                workerConfiguration.setDisplayName("Comparing " + current + " with " + baseline);
+                workerConfiguration.setDisplayName("JApicmp check comparing " + current + " with " + baseline);
                 workerConfiguration.params(
                         // we use a single configuration object, instead of passing each parameter directly,
                         // because the worker API doesn't support "null" values


### PR DESCRIPTION
Currently the console logs say:

> A failure occurred while executing Comparing (list of binaries)

This change makes it clear that the JApicmp check specifically is the one failing. 