### PR TITLE
Fix Gradle 6.0 deprecations

### DIFF
--- a/src/main/java/me/champeau/gradle/japicmp/JapicmpTask.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JapicmpTask.java
@@ -97,8 +97,8 @@ public class JapicmpTask extends DefaultTask {
                         // we use a single configuration object, instead of passing each parameter directly,
                         // because the worker API doesn't support "null" values
                         new JapiCmpWorkerConfiguration(
-                                getIncludeSynthetic(),
-                                getIgnoreMissingClasses(),
+                                isIncludeSynthetic(),
+                                isIgnoreMissingClasses(),
                                 getPackageIncludes(),
                                 getPackageExcludes(),
                                 getClassIncludes(),
@@ -115,14 +115,14 @@ public class JapicmpTask extends DefaultTask {
                                 toArchives(getNewClasspath()),
                                 baseline,
                                 current,
-                                getOnlyModified(),
-                                getOnlyBinaryIncompatibleModified(),
-                                getFailOnSourceIncompatibility(),
+                                isOnlyModified(),
+                                isOnlyBinaryIncompatibleModified(),
+                                isFailOnSourceIncompatibility(),
                                 getAccessModifier(),
                                 getXmlOutputFile(),
                                 getHtmlOutputFile(),
                                 getTxtOutputFile(),
-                                getFailOnModification(),
+                                isFailOnModification(),
                                 getProject().getBuildDir(),
                                 richReport
                         )
@@ -332,10 +332,6 @@ public class JapicmpTask extends DefaultTask {
     }
 
     @Input
-    public boolean getOnlyModified() {
-        return onlyModified;
-    }
-
     public boolean isOnlyModified() {
         return onlyModified;
     }
@@ -345,10 +341,6 @@ public class JapicmpTask extends DefaultTask {
     }
 
     @Input
-    public boolean getOnlyBinaryIncompatibleModified() {
-        return onlyBinaryIncompatibleModified;
-    }
-
     public boolean isOnlyBinaryIncompatibleModified() {
         return onlyBinaryIncompatibleModified;
     }
@@ -358,7 +350,7 @@ public class JapicmpTask extends DefaultTask {
     }
 
     @Input
-    public boolean getFailOnSourceIncompatibility() {
+    public boolean isFailOnSourceIncompatibility() {
         return failOnSourceIncompatibility;
     }
 
@@ -397,10 +389,6 @@ public class JapicmpTask extends DefaultTask {
     }
 
     @Input
-    public boolean getFailOnModification() {
-        return failOnModification;
-    }
-
     public boolean isFailOnModification() {
         return failOnModification;
     }
@@ -410,10 +398,6 @@ public class JapicmpTask extends DefaultTask {
     }
 
     @Input
-    public boolean getIncludeSynthetic() {
-        return includeSynthetic;
-    }
-
     public boolean isIncludeSynthetic() {
         return includeSynthetic;
     }
@@ -461,10 +445,6 @@ public class JapicmpTask extends DefaultTask {
     }
 
     @Input
-    public boolean getIgnoreMissingClasses() {
-        return ignoreMissingClasses;
-    }
-
     public boolean isIgnoreMissingClasses() {
         return ignoreMissingClasses;
     }

--- a/src/main/java/me/champeau/gradle/japicmp/JapicmpTask.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JapicmpTask.java
@@ -332,7 +332,6 @@ public class JapicmpTask extends DefaultTask {
     }
 
     @Input
-    @Optional
     public boolean getOnlyModified() {
         return onlyModified;
     }
@@ -346,7 +345,6 @@ public class JapicmpTask extends DefaultTask {
     }
 
     @Input
-    @Optional
     public boolean getOnlyBinaryIncompatibleModified() {
         return onlyBinaryIncompatibleModified;
     }
@@ -360,7 +358,6 @@ public class JapicmpTask extends DefaultTask {
     }
 
     @Input
-    @Optional
     public boolean getFailOnSourceIncompatibility() {
         return failOnSourceIncompatibility;
     }
@@ -400,7 +397,6 @@ public class JapicmpTask extends DefaultTask {
     }
 
     @Input
-    @Optional
     public boolean getFailOnModification() {
         return failOnModification;
     }
@@ -414,7 +410,6 @@ public class JapicmpTask extends DefaultTask {
     }
 
     @Input
-    @Optional
     public boolean getIncludeSynthetic() {
         return includeSynthetic;
     }
@@ -465,7 +460,6 @@ public class JapicmpTask extends DefaultTask {
         this.newArchives = newArchives;
     }
 
-    @Optional
     @Input
     public boolean getIgnoreMissingClasses() {
         return ignoreMissingClasses;

--- a/src/main/java/me/champeau/gradle/japicmp/report/RichReport.java
+++ b/src/main/java/me/champeau/gradle/japicmp/report/RichReport.java
@@ -147,7 +147,6 @@ public class RichReport implements Serializable {
     }
 
     @Input
-    @Optional
     public boolean isAddDefaultRules() {
         return addDefaultRules;
     }


### PR DESCRIPTION
When used with Gradle 6.0, we see some deprecations in the https://github.com/gradle/gradle build. See for example: https://e.grdev.net/s/zq4o26pijn2le/deprecations?openUsages=WzIsM10

This PR fixes the deprecations by
- Removing redundant getters for `boolean` properties
- Removing `@Optional` for `boolean` properties