### PR TITLE
Support Gradle 5.6

### DIFF
--- a/gradle/compile.gradle
+++ b/gradle/compile.gradle
@@ -23,7 +23,6 @@ repositories {
 
 dependencies {
     compile('com.github.siom79.japicmp:japicmp:0.14.0') {
-        exclude group:'com.google.guava'
         exclude group:'io.airlift'
         exclude group:'javax.xml.bind'
         exclude group:'com.sun.xml.bind'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jul 07 13:52:23 CEST 2017
+#Sun Jan 12 14:03:07 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip


### PR DESCRIPTION
Attempts to fix #36.

The missing classes were from Guava, so I un-excluded Guava from the dependency declarations—I'm not sure why it was excluded before so I don't know if this is acceptable.

Other than the missing Guava class errors, 4 other tests fail with Gradle 5.6+. I'm a bit over my head in debugging those errors at the moment but this is at least a start toward Gradle 5.6 support.