### PR TITLE
Make the report link stand out from the output

### DIFF
--- a/src/main/java/me/champeau/gradle/japicmp/JApiCmpWorkerAction.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JApiCmpWorkerAction.java
@@ -311,7 +311,8 @@ public class JApiCmpWorkerAction extends JapiCmpWorkerConfiguration implements R
                     .append(" and ")
                     .append(prettyPrint(baseline));
             if (reportLink != null) {
-                message.append(". See failure report at ").append(reportLink);
+                message.append(".").append(System.lineSeparator()).append(System.lineSeparator());
+                message.append("See failure report at ").append(reportLink);
             }
             throw new GradleException(message.toString());
         }


### PR DESCRIPTION
 Currently the report link is inline with the rest of the affected
 classpath. With a large classpath, you end up with a wall of
 text that only lists jars and it is easy to miss the link to the
 readable report at the end of it.