### PR TITLE
Rework the plugin to be compatible with Gradle's configuration cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildScanRecipes {
 apply plugin: 'idea'
 apply from: 'gradle/credentials.gradle'
 apply from: 'gradle/compile.gradle'
+apply from: 'gradle/test.gradle'
 apply from: 'gradle/publishing.gradle'
 
 dependencies {

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -1,7 +1,11 @@
 import org.gradle.util.GradleVersion
 
 def wrapperVersion = GradleVersion.current().version
-def testedGradleVersions = (['4.0', '4.10.3', '5.6.4', '6.9.1', '7.2'] - wrapperVersion) as SortedSet
+
+// The plugin is broken with Gradle 5.6.*
+def otherVersions = ['4.0', '4.10.3', /*'5.6.4',*/ '6.9.1', '7.2']
+
+def testedGradleVersions = (otherVersions - wrapperVersion) as SortedSet
 
 def test = tasks.named("test")
 def check = tasks.named("check")

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -1,0 +1,34 @@
+import org.gradle.util.GradleVersion
+
+def wrapperVersion = GradleVersion.current().version
+def testedGradleVersions = (['4.0', '4.10.3', '5.6.4', '6.9.1', '7.2'] - wrapperVersion) as SortedSet
+
+def test = tasks.named("test")
+def check = tasks.named("check")
+
+test.configure {
+    description = "Runs the tests against Gradle $wrapperVersion"
+    systemProperty "gradleVersion", wrapperVersion
+}
+
+def testAllGradleVersions = tasks.register("testAllGradleVersions") {
+    group = "verification"
+    description = "Runs the tests against all supported Gradle versions"
+    dependsOn(test)
+}
+
+check.configure {
+    dependsOn(testAllGradleVersions)
+}
+
+testedGradleVersions.each { gradleVersion ->
+    def task = tasks.register("testGradle${gradleVersion.replace(".", "_").replace("-", "_")}", Test) {
+        group = "verification"
+        description = "Runs the tests against Gradle $gradleVersion"
+        classpath = test.get().classpath
+        systemProperty "gradleVersion", gradleVersion
+    }
+    testAllGradleVersions.configure {
+        dependsOn(task)
+    }
+}

--- a/src/main/java/me/champeau/gradle/japicmp/JApiCmpWorkerAction.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JApiCmpWorkerAction.java
@@ -93,8 +93,8 @@ public class JApiCmpWorkerAction extends JapiCmpWorkerConfiguration implements R
                 configuration.htmlOutputFile,
                 configuration.txtOutputFile,
                 configuration.failOnModification,
-                configuration.buildDir,
-                configuration.richReport);
+                configuration.richReport,
+                configuration.richReportFallbackDestinationDir);
     }
 
     private JarArchiveComparatorOptions createOptions() {
@@ -287,7 +287,7 @@ public class JApiCmpWorkerAction extends JapiCmpWorkerConfiguration implements R
             }
             File path = richReport.getDestinationDir();
             if (path == null) {
-                path = new File(buildDir, "reports");
+                path = richReportFallbackDestinationDir;
             }
 
             try {

--- a/src/main/java/me/champeau/gradle/japicmp/JapiCmpWorkerConfiguration.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JapiCmpWorkerConfiguration.java
@@ -49,8 +49,8 @@ public class JapiCmpWorkerConfiguration implements Serializable {
     protected final File htmlOutputFile;
     protected final File txtOutputFile;
     protected final boolean failOnModification;
-    protected final File buildDir;
     protected final RichReport richReport;
+    protected final File richReportFallbackDestinationDir;
 
     public JapiCmpWorkerConfiguration(final boolean includeSynthetic,
                                       final boolean ignoreMissingClasses,
@@ -78,8 +78,8 @@ public class JapiCmpWorkerConfiguration implements Serializable {
                                       final File htmlOutputFile,
                                       final File txtOutputFile,
                                       final boolean failOnModification,
-                                      final File buildDir,
-                                      final RichReport richReport) {
+                                      final RichReport richReport,
+                                      final File richReportFallbackDestinationDir) {
         this.includeSynthetic = includeSynthetic;
         this.ignoreMissingClasses = ignoreMissingClasses;
         this.packageIncludes = packageIncludes;
@@ -106,8 +106,8 @@ public class JapiCmpWorkerConfiguration implements Serializable {
         this.htmlOutputFile = htmlOutputFile;
         this.txtOutputFile = txtOutputFile;
         this.failOnModification = failOnModification | failOnSourceIncompatibility;
-        this.buildDir = buildDir;
         this.richReport = richReport;
+        this.richReportFallbackDestinationDir = richReportFallbackDestinationDir;
     }
 
 }

--- a/src/main/java/me/champeau/gradle/japicmp/JapicmpTask.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JapicmpTask.java
@@ -22,6 +22,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.workers.IsolationMode;
 import org.gradle.workers.WorkerConfiguration;
 import org.gradle.workers.WorkerExecutor;
+import org.gradle.util.GradleVersion;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -89,6 +90,9 @@ public class JapicmpTask extends DefaultTask {
                 if (JavaVersion.current().isJava9Compatible()) {
                     classpath.addAll(resolveJaxb().getFiles());
                 }
+                if (GradleVersion.current().compareTo(GradleVersion.version("6.0")) >= 0) {
+                    classpath.addAll(resolveGuava().getFiles());
+                }
                 workerConfiguration.setClasspath(classpath);
                 List<JApiCmpWorkerAction.Archive> baseline = JapicmpTask.this.oldArchives != null ? toArchives(JapicmpTask.this.oldArchives) : inferArchives(oldClasspath);
                 List<JApiCmpWorkerAction.Archive> current = JapicmpTask.this.newArchives != null ? toArchives(JapicmpTask.this.newArchives) : inferArchives(newClasspath);
@@ -140,6 +144,14 @@ public class JapicmpTask extends DefaultTask {
                 dependencies.create("com.sun.xml.bind:jaxb-core:2.3.0.1"),
                 dependencies.create("com.sun.xml.bind:jaxb-impl:2.3.0.1"),
                 dependencies.create("javax.activation:activation:1.1.1")
+        );
+    }
+
+    private Configuration resolveGuava() {
+        Project project = getProject();
+        DependencyHandler dependencies = project.getDependencies();
+        return project.getConfigurations().detachedConfiguration(
+                dependencies.create("com.google.guava:guava:30.1.1-jre")
         );
     }
 

--- a/src/main/java/me/champeau/gradle/japicmp/JapicmpTask.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JapicmpTask.java
@@ -65,9 +65,9 @@ public class JapicmpTask extends DefaultTask {
     private FileCollection newArchives;
     private boolean ignoreMissingClasses = false;
     private RichReport richReport;
+    private final File richReportFallbackDestinationDir;
 
     public JapicmpTask() {
-        getProject().getLayout();
         ConfigurableFileCollection classpath = getProject().files();
         if (JavaVersion.current().isJava9Compatible()) {
             classpath.from(resolveJaxb());
@@ -76,6 +76,7 @@ public class JapicmpTask extends DefaultTask {
             classpath.from(resolveGuava());
         }
         additionalJapicmpClasspath = classpath;
+        richReportFallbackDestinationDir = new File(getProject().getBuildDir(), "reports");
     }
 
     @TaskAction
@@ -136,8 +137,8 @@ public class JapicmpTask extends DefaultTask {
                                 getHtmlOutputFile(),
                                 getTxtOutputFile(),
                                 isFailOnModification(),
-                                getProject().getBuildDir(),
-                                richReport
+                                richReport,
+                                richReportFallbackDestinationDir
                         )
                 );
             }

--- a/src/test/groovy/me/champeau/gradle/AnnotationFilteringTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/AnnotationFilteringTest.groovy
@@ -14,6 +14,12 @@ class AnnotationFilteringTest extends BaseFunctionalTest {
         hasTextReport('MODIFIED METHOD: PUBLIC void (<-int) stableMethod()')
         def report = getReport('japi', 'txt').text
         !report.contains('MODIFIED METHOD: PUBLIC void (<-int) betaMethod()')
+
+        when:
+        result = run 'japicmpOnlyCheckStableApi'
+
+        then:
+        result.task(":japicmpOnlyCheckStableApi").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "excluding @BetaApi hides beta methods"() {
@@ -25,5 +31,11 @@ class AnnotationFilteringTest extends BaseFunctionalTest {
         hasTextReport('MODIFIED METHOD: PUBLIC void (<-int) stableMethod()')
         def report = getReport('japi', 'txt').text
         !report.contains('MODIFIED METHOD: PUBLIC void (<-int) betaMethod()')
+
+        when:
+        result = run 'japicmpExcludeBetaApi'
+
+        then:
+        result.task(":japicmpExcludeBetaApi").outcome == TaskOutcome.UP_TO_DATE
     }
 }

--- a/src/test/groovy/me/champeau/gradle/BaseFunctionalTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/BaseFunctionalTest.groovy
@@ -98,11 +98,15 @@ abstract class BaseFunctionalTest extends Specification {
         System.getProperty("gradleVersion")
     }
 
+    protected boolean supportsConfigurationCache = true
+
     private List<String> getExtraArguments() {
-        def extraArgs = ['-s']
+        def extraArgs = ['--stacktrace']
         def version = GradleVersion.version(gradleVersion)
-        if(version >= GradleVersion.version('7.2')) {
-            extraArgs << '--configuration-cache'
+        if (version >= GradleVersion.version('7.2')) {
+            if (supportsConfigurationCache) {
+                extraArgs << '--configuration-cache'
+            }
         }
         return extraArgs
     }

--- a/src/test/groovy/me/champeau/gradle/BaseFunctionalTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/BaseFunctionalTest.groovy
@@ -77,6 +77,7 @@ abstract class BaseFunctionalTest extends Specification {
 
     BuildResult run(String... tasks) {
         GradleRunner.create()
+                .withGradleVersion(gradleVersion)
                 .withProjectDir(testProjectDir.root)
                 .withArguments('-s', *(tasks as List))
                 .withPluginClasspath()
@@ -85,9 +86,14 @@ abstract class BaseFunctionalTest extends Specification {
 
     BuildResult fails(String... tasks) {
         GradleRunner.create()
+                .withGradleVersion(gradleVersion)
                 .withProjectDir(testProjectDir.root)
                 .withArguments('-s', *(tasks as List))
                 .withPluginClasspath()
                 .buildAndFail()
+    }
+
+    String getGradleVersion() {
+        System.getProperty("gradleVersion")
     }
 }

--- a/src/test/groovy/me/champeau/gradle/BaseFunctionalTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/BaseFunctionalTest.groovy
@@ -2,6 +2,7 @@ package me.champeau.gradle
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.util.GradleVersion
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
@@ -79,7 +80,7 @@ abstract class BaseFunctionalTest extends Specification {
         GradleRunner.create()
                 .withGradleVersion(gradleVersion)
                 .withProjectDir(testProjectDir.root)
-                .withArguments('-s', *(tasks as List))
+                .withArguments(*(extraArguments + (tasks as List)))
                 .withPluginClasspath()
                 .build()
     }
@@ -88,12 +89,21 @@ abstract class BaseFunctionalTest extends Specification {
         GradleRunner.create()
                 .withGradleVersion(gradleVersion)
                 .withProjectDir(testProjectDir.root)
-                .withArguments('-s', *(tasks as List))
+                .withArguments(*(extraArguments + (tasks as List)))
                 .withPluginClasspath()
                 .buildAndFail()
     }
 
-    String getGradleVersion() {
+    private String getGradleVersion() {
         System.getProperty("gradleVersion")
+    }
+
+    private List<String> getExtraArguments() {
+        def extraArgs = ['-s']
+        def version = GradleVersion.version(gradleVersion)
+        if(version >= GradleVersion.version('7.2')) {
+            extraArgs << '--configuration-cache'
+        }
+        return extraArgs
     }
 }

--- a/src/test/groovy/me/champeau/gradle/Compare2JarsFunctionalTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/Compare2JarsFunctionalTest.groovy
@@ -14,6 +14,12 @@ class Compare2JarsFunctionalTest extends BaseFunctionalTest {
         hasTextReport('UNCHANGED CLASS: PUBLIC org.apache.commons.lang3.AnnotationUtils')
         noHtmlReport()
         noRichReport()
+
+        when:
+        result = run 'japicmp'
+
+        then:
+        result.task(":japicmp").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "can compare 2 jars using explicit archives property"() {
@@ -25,5 +31,11 @@ class Compare2JarsFunctionalTest extends BaseFunctionalTest {
         hasTextReport('UNCHANGED CLASS: PUBLIC org.apache.commons.lang3.AnnotationUtils')
         noHtmlReport()
         noRichReport()
+
+        when:
+        result = run 'japicmpWithExplicitClasspath'
+
+        then:
+        result.task(":japicmpWithExplicitClasspath").outcome == TaskOutcome.UP_TO_DATE
     }
 }

--- a/src/test/groovy/me/champeau/gradle/Compare2LibrariesFunctionalTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/Compare2LibrariesFunctionalTest.groovy
@@ -14,5 +14,11 @@ class Compare2LibrariesFunctionalTest extends BaseFunctionalTest {
         hasTextReport('UNCHANGED CLASS: PUBLIC org.apache.commons.lang3.AnnotationUtils')
         noHtmlReport()
         noRichReport()
+
+        when:
+        result = run 'japicmp'
+
+        then:
+        result.task(":japicmp").outcome == TaskOutcome.UP_TO_DATE
     }
 }

--- a/src/test/groovy/me/champeau/gradle/CustomFilteringTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/CustomFilteringTest.groovy
@@ -21,6 +21,13 @@ class CustomFilteringTest extends BaseFunctionalTest {
         hasTextReport('REMOVED METHOD: PUBLIC(-) void someMethod()')
 
         when:
+        result = run 'japicmpAddCustomMatchTriggers'
+
+        then:
+        println(result.output)
+        result.task(":japicmpAddCustomMatchTriggers").outcome == TaskOutcome.UP_TO_DATE
+
+        when:
         result = run 'japicmpRemoveCustomMatchTriggers'
 
         then:
@@ -28,5 +35,12 @@ class CustomFilteringTest extends BaseFunctionalTest {
         result.task(":japicmpRemoveCustomMatchTriggers").outcome == TaskOutcome.SUCCESS
         hasTextReport('NEW FIELD: PUBLIC(+) java.lang.String someField')
         hasTextReport('NEW METHOD: PUBLIC(+) void someMethod()')
+
+        when:
+        result = run 'japicmpRemoveCustomMatchTriggers'
+
+        then:
+        println(result.output)
+        result.task(":japicmpRemoveCustomMatchTriggers").outcome == TaskOutcome.UP_TO_DATE
     }
 }

--- a/src/test/groovy/me/champeau/gradle/CustomFilteringTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/CustomFilteringTest.groovy
@@ -11,6 +11,8 @@ class CustomFilteringTest extends BaseFunctionalTest {
     }
 
     def "can use custom japicmp filters"() {
+        supportsConfigurationCache = false
+
         when:
         def result = run 'japicmpAddCustomMatchTriggers'
 

--- a/src/test/groovy/me/champeau/gradle/DefaultRulesRichReportFunctionalTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/DefaultRulesRichReportFunctionalTest.groovy
@@ -15,6 +15,12 @@ class DefaultRulesRichReportFunctionalTest extends BaseFunctionalTest {
         report =~ '<a class=\'navbar-brand\' href=\'#\'>Binary compatibility report</a>'
         report =~ 'Class org.apache.commons.lang3.time.FastDateFormat: Is not binary compatible'
         report =~ 'Class org.apache.commons.lang3.CharSetUtils: has been modified in source compatible way'
+
+        when:
+        result = fails "japicmp"
+
+        then:
+        result.task(":japicmp").outcome == TaskOutcome.FAILED
     }
 
 }

--- a/src/test/groovy/me/champeau/gradle/FieldFilteringTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/FieldFilteringTest.groovy
@@ -14,6 +14,12 @@ class FieldFilteringTest extends BaseFunctionalTest {
         hasTextReport('MODIFIED FIELD: PUBLIC java.lang.String (<- int) bad')
         def report = getReport('japi', 'txt').text
         !report.contains('UNCHANGED FIELD: PUBLIC java.lang.String unchanged')
+
+        when:
+        result = run 'japicmpFieldIncludeOnlyBad'
+
+        then:
+        result.task(":japicmpFieldIncludeOnlyBad").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "including only good field"() {
@@ -25,6 +31,12 @@ class FieldFilteringTest extends BaseFunctionalTest {
         hasTextReport('UNCHANGED FIELD: PUBLIC java.lang.String unchanged')
         def report = getReport('japi', 'txt').text
         !report.contains('MODIFIED FIELD: PUBLIC java.lang.String (<- int) bad')
+
+        when:
+        result = run 'japicmpFieldIncludeOnlyGood'
+
+        then:
+        result.task(":japicmpFieldIncludeOnlyGood").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "excluding good field"() {
@@ -36,6 +48,12 @@ class FieldFilteringTest extends BaseFunctionalTest {
         hasTextReport('MODIFIED FIELD: PUBLIC java.lang.String (<- int) bad')
         def report = getReport('japi', 'txt').text
         !report.contains('UNCHANGED FIELD: PUBLIC java.lang.String unchanged')
+
+        when:
+        result = run 'japiCmpFieldExcludeKeepBad'
+
+        then:
+        result.task(":japiCmpFieldExcludeKeepBad").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "excluding bad field"() {
@@ -47,5 +65,11 @@ class FieldFilteringTest extends BaseFunctionalTest {
         hasTextReport('UNCHANGED FIELD: PUBLIC java.lang.String unchanged')
         def report = getReport('japi', 'txt').text
         !report.contains('MODIFIED FIELD: PUBLIC java.lang.String (<- int) bad')
+
+        when:
+        result = run 'japicmpFieldExcludeKeepGood'
+
+        then:
+        result.task(":japicmpFieldExcludeKeepGood").outcome == TaskOutcome.UP_TO_DATE
     }
 }

--- a/src/test/groovy/me/champeau/gradle/MethodFilteringTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/MethodFilteringTest.groovy
@@ -14,6 +14,12 @@ class MethodFilteringTest extends BaseFunctionalTest {
         hasTextReport('MODIFIED METHOD: PUBLIC void (<-int) getInteger()')
         def report = getReport('japi', 'txt').text
         !report.contains('UNCHANGED METHOD: PUBLIC void unchanged()')
+
+        when:
+        result = run 'japicmpMethodIncludeOnlyBad'
+
+        then:
+        result.task(":japicmpMethodIncludeOnlyBad").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "including only good method"() {
@@ -25,6 +31,12 @@ class MethodFilteringTest extends BaseFunctionalTest {
         hasTextReport('UNCHANGED METHOD: PUBLIC void unchanged()')
         def report = getReport('japi', 'txt').text
         !report.contains('MODIFIED METHOD: PUBLIC void (<-int) getInteger()')
+
+        when:
+        result = run 'japicmpMethodIncludeOnlyGood'
+
+        then:
+        result.task(":japicmpMethodIncludeOnlyGood").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "excluding good method"() {
@@ -36,6 +48,12 @@ class MethodFilteringTest extends BaseFunctionalTest {
         hasTextReport('MODIFIED METHOD: PUBLIC void (<-int) getInteger()')
         def report = getReport('japi', 'txt').text
         !report.contains('UNCHANGED METHOD: PUBLIC void unchanged()')
+
+        when:
+        result = run 'japiCmpMethodExcludeKeepBad'
+
+        then:
+        result.task(":japiCmpMethodExcludeKeepBad").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "excluding bad method"() {
@@ -47,5 +65,11 @@ class MethodFilteringTest extends BaseFunctionalTest {
         hasTextReport('UNCHANGED METHOD: PUBLIC void unchanged()')
         def report = getReport('japi', 'txt').text
         !report.contains('MODIFIED METHOD: PUBLIC void (<-int) getInteger()')
+
+        when:
+        result = run 'japicmpMethodExcludeKeepGood'
+
+        then:
+        result.task(":japicmpMethodExcludeKeepGood").outcome == TaskOutcome.UP_TO_DATE
     }
 }

--- a/src/test/groovy/me/champeau/gradle/PackageAndClassFilteringTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/PackageAndClassFilteringTest.groovy
@@ -14,6 +14,12 @@ class PackageAndClassFilteringTest extends BaseFunctionalTest {
         hasTextReport('MODIFIED CLASS: PUBLIC me.champeau.gradle.japicmp.bad.Bad')
         def report = getReport('japi', 'txt').text
         !report.contains('me.champeau.gradle.japicmp.good.Good')
+
+        when:
+        result = run 'japicmpPackageIncludeOnlyBad'
+
+        then:
+        result.task(":japicmpPackageIncludeOnlyBad").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "including only good package"() {
@@ -25,6 +31,12 @@ class PackageAndClassFilteringTest extends BaseFunctionalTest {
         hasTextReport('UNCHANGED CLASS: PUBLIC me.champeau.gradle.japicmp.good.Good')
         def report = getReport('japi', 'txt').text
         !report.contains('me.champeau.gradle.japicmp.bad.Bad')
+
+        when:
+        result = run 'japicmpPackageIncludeOnlyGood'
+
+        then:
+        result.task(":japicmpPackageIncludeOnlyGood").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "excluding good package"() {
@@ -36,6 +48,12 @@ class PackageAndClassFilteringTest extends BaseFunctionalTest {
         hasTextReport('MODIFIED CLASS: PUBLIC me.champeau.gradle.japicmp.bad.Bad')
         def report = getReport('japi', 'txt').text
         !report.contains('me.champeau.gradle.japicmp.good.Good')
+
+        when:
+        result = run 'japiCmpPackageExcludeKeepBad'
+
+        then:
+        result.task(":japiCmpPackageExcludeKeepBad").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "excluding bad package"() {
@@ -47,6 +65,12 @@ class PackageAndClassFilteringTest extends BaseFunctionalTest {
         hasTextReport('UNCHANGED CLASS: PUBLIC me.champeau.gradle.japicmp.good.Good')
         def report = getReport('japi', 'txt').text
         !report.contains('me.champeau.gradle.japicmp.bad.Bad')
+
+        when:
+        result = run 'japicmpPackageExcludeKeepGood'
+
+        then:
+        result.task(":japicmpPackageExcludeKeepGood").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "including only bad class"() {
@@ -58,6 +82,12 @@ class PackageAndClassFilteringTest extends BaseFunctionalTest {
         hasTextReport('MODIFIED CLASS: PUBLIC me.champeau.gradle.japicmp.bad.Bad')
         def report = getReport('japi', 'txt').text
         !report.contains('me.champeau.gradle.japicmp.good.Good')
+
+        when:
+        result = run 'japicmpClassIncludeOnlyBad'
+
+        then:
+        result.task(":japicmpClassIncludeOnlyBad").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "including only good class"() {
@@ -69,6 +99,12 @@ class PackageAndClassFilteringTest extends BaseFunctionalTest {
         hasTextReport('UNCHANGED CLASS: PUBLIC me.champeau.gradle.japicmp.good.Good')
         def report = getReport('japi', 'txt').text
         !report.contains('me.champeau.gradle.japicmp.bad.Bad')
+
+        when:
+        result = run 'japicmpClassIncludeOnlyGood'
+
+        then:
+        result.task(":japicmpClassIncludeOnlyGood").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "excluding good class"() {
@@ -80,6 +116,12 @@ class PackageAndClassFilteringTest extends BaseFunctionalTest {
         hasTextReport('MODIFIED CLASS: PUBLIC me.champeau.gradle.japicmp.bad.Bad')
         def report = getReport('japi', 'txt').text
         !report.contains('me.champeau.gradle.japicmp.good.Good')
+
+        when:
+        result = run 'japiCmpClassExcludeKeepBad'
+
+        then:
+        result.task(":japiCmpClassExcludeKeepBad").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "excluding bad class"() {
@@ -91,5 +133,11 @@ class PackageAndClassFilteringTest extends BaseFunctionalTest {
         hasTextReport('UNCHANGED CLASS: PUBLIC me.champeau.gradle.japicmp.good.Good')
         def report = getReport('japi', 'txt').text
         !report.contains('me.champeau.gradle.japicmp.bad.Bad')
+
+        when:
+        result = run 'japicmpClassExcludeKeepGood'
+
+        then:
+        result.task(":japicmpClassExcludeKeepGood").outcome == TaskOutcome.UP_TO_DATE
     }
 }

--- a/src/test/groovy/me/champeau/gradle/ReportsFunctionalTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/ReportsFunctionalTest.groovy
@@ -14,6 +14,12 @@ class ReportsFunctionalTest extends BaseFunctionalTest {
         hasHtmlReport('<a href="#org.apache.commons.lang3.event.EventListenerSupport">')
         noTxtReport()
         noRichReport()
+
+        when:
+        result = run 'japicmp'
+
+        then:
+        result.task(":japicmp").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "can generate rich report"() {
@@ -26,5 +32,11 @@ class ReportsFunctionalTest extends BaseFunctionalTest {
         hasRichReport('A test of rich report')
         noTxtReport()
         noHtmlReport()
+
+        when:
+        result = run 'japicmpRich'
+
+        then:
+        result.task(":japicmpRich").outcome == TaskOutcome.UP_TO_DATE
     }
 }

--- a/src/test/groovy/me/champeau/gradle/RichReportFunctionalTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/RichReportFunctionalTest.groovy
@@ -8,6 +8,8 @@ class RichReportFunctionalTest extends BaseFunctionalTest {
 
     @Unroll("can generate rich report with #type rules")
     def "can generate rich report with rules"() {
+        supportsConfigurationCache = false
+
         def task = "japicmp${type.capitalize()}"
         when:
         def result = run task

--- a/src/test/groovy/me/champeau/gradle/RichReportFunctionalTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/RichReportFunctionalTest.groovy
@@ -8,8 +8,9 @@ class RichReportFunctionalTest extends BaseFunctionalTest {
 
     @Unroll("can generate rich report with #type rules")
     def "can generate rich report with rules"() {
+        def task = "japicmp${type.capitalize()}"
         when:
-        def result = run "japicmp${type.capitalize()}"
+        def result = run task
 
         then:
         result.task(":japicmp${type.capitalize()}").outcome == TaskOutcome.SUCCESS
@@ -17,6 +18,12 @@ class RichReportFunctionalTest extends BaseFunctionalTest {
         report =~ '<a class=\'navbar-brand\' href=\'#\'>Binary compatibility report</a>'
         report =~ 'A test of rich report'
         report =~ 'This class is deprecated'
+
+        when:
+        result = run task
+
+        then:
+        result.task(":$task").outcome == TaskOutcome.UP_TO_DATE
 
         where:
         type << ['generic', 'status', 'change']

--- a/src/test/groovy/me/champeau/gradle/SourceIncompatibleChange.groovy
+++ b/src/test/groovy/me/champeau/gradle/SourceIncompatibleChange.groovy
@@ -11,6 +11,12 @@ class SourceIncompatibleChangeTest extends BaseFunctionalTest {
 
         then:
         result.task(":japicmpIgnoresSourceCompatabilityByDefault").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = run 'japicmpIgnoresSourceCompatabilityByDefault'
+
+        then:
+        result.task(":japicmpIgnoresSourceCompatabilityByDefault").outcome == TaskOutcome.UP_TO_DATE
     }
 
     def "source incompatibility breaks build"() {
@@ -19,11 +25,23 @@ class SourceIncompatibleChangeTest extends BaseFunctionalTest {
 
         then:
         result.task(":japicmpFailsOnSourceIncompatability").outcome == TaskOutcome.FAILED
+
+        when:
+        result = fails 'japicmpFailsOnSourceIncompatability'
+
+        then:
+        result.task(":japicmpFailsOnSourceIncompatability").outcome == TaskOutcome.FAILED
     }
 
     def "source incompatibility breaks build (non-public access)"() {
         when:
         def result = fails "japicmpFailsOnSourceIncompatabilityNonPublic"
+
+        then:
+        result.task(":japicmpFailsOnSourceIncompatabilityNonPublic").outcome == TaskOutcome.FAILED
+
+        when:
+        result = fails 'japicmpFailsOnSourceIncompatabilityNonPublic'
 
         then:
         result.task(":japicmpFailsOnSourceIncompatabilityNonPublic").outcome == TaskOutcome.FAILED


### PR DESCRIPTION
This PR fixes the plugin to work with Gradle's configuration cache for most use cases.

Along the way, introducing cross-gradle-version testing was implemented. Tests running on Gradle >= 7.2 now always run with the configuration cache enabled. The coverage showed that the plugin is broken with Gradle 5.6.x might be related to https://github.com/melix/japicmp-gradle-plugin/issues/36

There are a couple tests that don't pass with the configuration cache enabled. This is due to some classloading issue in CC implementation. Each of these use case works if the user classes aren't in a build script. I think this PR is already a good step, I would like to get it in first then investigate how to fix the issue in `gradle/gradle` and then come back here if needed in another PR.