### PR TITLE
Add violation transformers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+0.4.0
+-----
+   * Upgrade to the Provider API
+   * Drop support for older Gradle versions (requires 6+)
+   * Add support for violation transformers
 0.2.9
 -----
    * Upgrade to JApiCmp 0.14.3

--- a/src/main/java/me/champeau/gradle/japicmp/JApiCmpWorkerAction.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JApiCmpWorkerAction.java
@@ -46,6 +46,8 @@ import me.champeau.gradle.japicmp.report.StatusChangeViolationRuleConfiguration;
 import me.champeau.gradle.japicmp.report.Violation;
 import me.champeau.gradle.japicmp.report.ViolationRule;
 import me.champeau.gradle.japicmp.report.ViolationRuleConfiguration;
+import me.champeau.gradle.japicmp.report.ViolationTransformer;
+import me.champeau.gradle.japicmp.report.ViolationTransformerConfiguration;
 import me.champeau.gradle.japicmp.report.ViolationsGenerator;
 import org.gradle.api.GradleException;
 
@@ -266,6 +268,8 @@ public class JApiCmpWorkerAction extends JapiCmpWorkerConfiguration implements R
                         generator.addRule(((StatusChangeViolationRuleConfiguration) configuration).getStatus(), (ViolationRule) rule);
                     } else if (configuration.getClass() == CompatibilityChangeViolationRuleConfiguration.class) {
                         generator.addRule(((CompatibilityChangeViolationRuleConfiguration) configuration).getChange(), (ViolationRule) rule);
+                    } else if (configuration.getClass() == ViolationTransformerConfiguration.class) {
+                        generator.addViolationTransformer((ViolationTransformer) rule);
                     }
                 } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
                     throw new GradleException("Unable to instantiate rule", e);

--- a/src/main/java/me/champeau/gradle/japicmp/report/RichReport.java
+++ b/src/main/java/me/champeau/gradle/japicmp/report/RichReport.java
@@ -67,6 +67,14 @@ public abstract class RichReport {
         addRule(status, rule, null);
     }
 
+    public void addViolationTransformer(Class<? extends ViolationTransformer> transformer) {
+        getRules().add(new ViolationTransformerConfiguration(transformer, null));
+    }
+
+    public void addViolationTransformer(Class<? extends ViolationTransformer> transformer, Map<String, String> params) {
+        getRules().add(new ViolationTransformerConfiguration(transformer, params));
+    }
+
     public void renderer(Class<? extends RichReportRenderer> rendererType) {
         this.getRenderer().set(rendererType);
     }

--- a/src/main/java/me/champeau/gradle/japicmp/report/Violation.java
+++ b/src/main/java/me/champeau/gradle/japicmp/report/Violation.java
@@ -142,6 +142,8 @@ public class Violation {
 
     public static String describe(JApiCompatibilityChange change) {
         switch (change) {
+            case ANNOTATION_DEPRECATED_ADDED:
+                return "Deprecated annotation was added";
             case CLASS_REMOVED:
                 return "Class has been removed";
             case CLASS_NOW_ABSTRACT:
@@ -154,6 +156,8 @@ public class Violation {
                 return "Class type changed";
             case CLASS_NOW_CHECKED_EXCEPTION:
                 return "Exception is now a checked exception";
+            case CLASS_LESS_ACCESSIBLE:
+                return "Class is less accessible";
             case SUPERCLASS_REMOVED:
                 return "Superclass has been removed";
             case SUPERCLASS_ADDED:
@@ -186,14 +190,24 @@ public class Violation {
                 return "Method is no longer static";
             case METHOD_ADDED_TO_INTERFACE:
                 return "Method added to interface";
+            case METHOD_ADDED_TO_PUBLIC_CLASS:
+                return "Method added to public class";
             case METHOD_NOW_THROWS_CHECKED_EXCEPTION:
                 return "Method is now throws a checked exception";
+            case METHOD_NO_LONGER_THROWS_CHECKED_EXCEPTION:
+                return "Method is no longer throws a checked exception";
             case METHOD_ABSTRACT_ADDED_TO_CLASS:
                 return "Abstract method has been added to this class";
             case METHOD_ABSTRACT_ADDED_IN_SUPERCLASS:
                 return "Abstract method has been added to a superclass";
             case METHOD_ABSTRACT_ADDED_IN_IMPLEMENTED_INTERFACE:
                 return "Abstract method has been added in implemented interface";
+            case METHOD_DEFAULT_ADDED_IN_IMPLEMENTED_INTERFACE:
+                return "Default method has been added in implemented interface";
+            case METHOD_NEW_DEFAULT:
+                return "Method now provides default implementation";
+            case METHOD_ABSTRACT_NOW_DEFAULT:
+                return "Abstract method is now default method";
             case FIELD_STATIC_AND_OVERRIDES_STATIC:
                 return "Field is static and overrides another static field";
             case FIELD_LESS_ACCESSIBLE_THAN_IN_SUPERCLASS:

--- a/src/main/java/me/champeau/gradle/japicmp/report/ViolationTransformer.java
+++ b/src/main/java/me/champeau/gradle/japicmp/report/ViolationTransformer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.gradle.japicmp.report;
+
+import java.util.Optional;
+
+@FunctionalInterface
+public interface ViolationTransformer {
+    /**
+     * Transforms the current violation.
+     * @param type the type on which the violation was found
+     * @param violation the violation
+     * @return a transformed violation. If the violation should be suppressed, return Optional.empty()
+     */
+    Optional<Violation> transform(String type, Violation violation);
+}

--- a/src/main/java/me/champeau/gradle/japicmp/report/ViolationTransformerConfiguration.java
+++ b/src/main/java/me/champeau/gradle/japicmp/report/ViolationTransformerConfiguration.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.champeau.gradle.japicmp.report;
+
+import java.util.Map;
+
+public class ViolationTransformerConfiguration extends RuleConfiguration<ViolationTransformer> {
+    public ViolationTransformerConfiguration(Class<? extends ViolationTransformer> ruleClass, Map<String, String> arguments) {
+        super(ruleClass, arguments);
+    }
+}


### PR DESCRIPTION
This commit introduces a facility to transform violations: this allows
rules to transform violations as they are added to the container. This
makes it easier, for example, to transform an error into a warning, or
update the message.