### PR TITLE
Add compatibilityChangeExcludes configuration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -61,6 +61,7 @@ fieldIncludes:: List of fields to include. Type: _List<String>_
 fieldExcludes:: List of fields to exclude. Type: _List<String>_
 annotationIncludes:: List of annotations to include. The string must begin with '@'. Type: _List<String>_
 annotationExcludes:: List of annotations to exclude. The string must begin with '@'. Type: _List<String>_
+compatibilityChangeExcludes:: List of compatibility changes to exclude, marking them as source and binary compatible. The string must match a value of the `japicmp.model.JApiCompatibilityChange` enum. Type: _List<String>_
 accessModifier:: Sets the access modifier level (public, package, protected, private). Type: _String_. Default value: _public_
 failOnSourceIncompatibility:: Fails if the changes result in source level incompatibility. Setting this to `true` also implicitly enables `failOnModification`. imType: _boolean_. Default value: _false_
 failOnModification:: When set to true, the build fails in case a modification has been detected. Type: _boolean_. Default value: _false_
@@ -89,6 +90,22 @@ tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask) {
     txtOutputFile = layout.buildDirectory.file("reports/japi.txt")
 }
 ----
+
+== JApiCompatibilityChange filtering
+
+The plugin supports simple exclusion for identified compatibility changes, turning these into binary and source
+compatible during API comparison:
+
+[source,groovy]
+----
+tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask) {
+   ...
+   compatibilityChangeExcludes = [ "METHOD_NEW_DEFAULT" ]
+}
+----
+
+The `JApiCompatibilityChange` enum from japicmp represents the list of identified compatibility changes which
+can be excluded. For simplicity, the plugin is configured with a _List<String>_ instead.
 
 == Custom filtering
 

--- a/src/main/java/me/champeau/gradle/japicmp/JApiCmpWorkerAction.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JApiCmpWorkerAction.java
@@ -18,6 +18,7 @@ package me.champeau.gradle.japicmp;
 import japicmp.cmp.JApiCmpArchive;
 import japicmp.cmp.JarArchiveComparator;
 import japicmp.cmp.JarArchiveComparatorOptions;
+import japicmp.cmp.JarArchiveComparatorOptions.OverrideCompatibilityChange;
 import japicmp.config.Options;
 import japicmp.filter.AnnotationBehaviorFilter;
 import japicmp.filter.AnnotationClassFilter;
@@ -29,6 +30,8 @@ import japicmp.filter.JavadocLikeFieldFilter;
 import japicmp.filter.JavadocLikePackageFilter;
 import japicmp.model.AccessModifier;
 import japicmp.model.JApiClass;
+import japicmp.model.JApiCompatibilityChange;
+import japicmp.model.JApiSemanticVersionLevel;
 import japicmp.output.stdout.StdoutOutputGenerator;
 import japicmp.output.xml.XmlOutput;
 import japicmp.output.xml.XmlOutputGenerator;
@@ -84,6 +87,7 @@ public class JApiCmpWorkerAction extends JapiCmpWorkerConfiguration implements R
                 configuration.annotationExcludes,
                 configuration.includeFilters,
                 configuration.excludeFilters,
+                configuration.compatibilityChangeExcludes,
                 configuration.oldClasspath,
                 configuration.newClasspath,
                 configuration.oldArchives,
@@ -143,6 +147,11 @@ public class JApiCmpWorkerAction extends JapiCmpWorkerConfiguration implements R
         }
         for (FilterConfiguration excludeFilter : excludeFilters) {
             options.getFilters().getExcludes().add(instantiateFilter(excludeFilter));
+        }
+        for (String override : compatibilityChangeExcludes) {
+            JApiCompatibilityChange overrideChange = JApiCompatibilityChange.valueOf(override);
+            options.addOverrideCompatibilityChange(new OverrideCompatibilityChange(overrideChange,
+                true, true, JApiSemanticVersionLevel.PATCH));
         }
 
         return options;

--- a/src/main/java/me/champeau/gradle/japicmp/JapiCmpWorkerConfiguration.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JapiCmpWorkerConfiguration.java
@@ -37,6 +37,7 @@ public class JapiCmpWorkerConfiguration implements Serializable {
     protected final List<String> annotationExcludes;
     protected final List<FilterConfiguration> includeFilters;
     protected final List<FilterConfiguration> excludeFilters;
+    protected final List<String> compatibilityChangeExcludes;
     protected final List<JApiCmpWorkerAction.Archive> oldClasspath;
     protected final List<JApiCmpWorkerAction.Archive> newClasspath;
     protected final List<JApiCmpWorkerAction.Archive> oldArchives;
@@ -65,6 +66,7 @@ public class JapiCmpWorkerConfiguration implements Serializable {
                                       final List<String> annotationExcludes,
                                       final List<FilterConfiguration> includeFilters,
                                       final List<FilterConfiguration> excludeFilters,
+                                      final List<String> compatibilityChangeExcludes,
                                       final List<JApiCmpWorkerAction.Archive> oldClasspath,
                                       final List<JApiCmpWorkerAction.Archive> newClasspath,
                                       final List<JApiCmpWorkerAction.Archive> oldArchives,
@@ -90,6 +92,7 @@ public class JapiCmpWorkerConfiguration implements Serializable {
         this.fieldExcludes = fieldExcludes;
         this.annotationIncludes = annotationIncludes;
         this.annotationExcludes = annotationExcludes;
+        this.compatibilityChangeExcludes = compatibilityChangeExcludes;
         this.includeFilters = includeFilters;
         this.excludeFilters = excludeFilters;
         this.oldClasspath = oldClasspath;

--- a/src/main/java/me/champeau/gradle/japicmp/JapicmpTask.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JapicmpTask.java
@@ -1,6 +1,7 @@
 package me.champeau.gradle.japicmp;
 
 import japicmp.filter.Filter;
+import japicmp.model.JApiCompatibilityChange;
 import me.champeau.gradle.japicmp.filters.FilterConfiguration;
 import me.champeau.gradle.japicmp.report.RichReport;
 import me.champeau.gradle.japicmp.report.RuleConfiguration;
@@ -124,6 +125,7 @@ public abstract class JapicmpTask extends DefaultTask {
                 getAnnotationExcludes().getOrElse(Collections.emptyList()),
                 getIncludeFilters().getOrElse(Collections.emptyList()),
                 getExcludeFilters().getOrElse(Collections.emptyList()),
+                getCompatibilityChangeExcludes().getOrElse(Collections.emptyList()),
                 toArchives(getOldClasspath()),
                 toArchives(getNewClasspath()),
                 baseline,
@@ -284,6 +286,10 @@ public abstract class JapicmpTask extends DefaultTask {
     public void addExcludeFilter(Class<? extends Filter> excludeFilterClass) {
         getExcludeFilters().add(new FilterConfiguration(excludeFilterClass));
     }
+
+    @Input
+    @Optional
+    public abstract ListProperty<String> getCompatibilityChangeExcludes();
 
     @Input
     @Optional

--- a/src/test/groovy/me/champeau/gradle/IncompatibleChangeExclusionTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/IncompatibleChangeExclusionTest.groovy
@@ -1,0 +1,49 @@
+package me.champeau.gradle
+
+import org.gradle.testkit.runner.TaskOutcome
+
+class IncompatibleChangeExclusionTest extends BaseFunctionalTest {
+    String testProject = 'incompatible-change-exclusion'
+
+    def "incompatible change detected by default"() {
+        when:
+        def result = fails "japicmpDetectsNewDefaultMethodByDefault"
+
+        then:
+        result.task(":japicmpDetectsNewDefaultMethodByDefault").outcome == TaskOutcome.FAILED
+
+        when:
+        result = fails 'japicmpDetectsNewDefaultMethodByDefault'
+
+        then:
+        result.task(":japicmpDetectsNewDefaultMethodByDefault").outcome == TaskOutcome.FAILED
+    }
+
+    def "incompatible change can be excluded"() {
+        when:
+        def result = run "configuredToIgnoreNewDefaultMethod"
+
+        then:
+        result.task(":configuredToIgnoreNewDefaultMethod").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = run 'configuredToIgnoreNewDefaultMethod'
+
+        then:
+        result.task(":configuredToIgnoreNewDefaultMethod").outcome == TaskOutcome.UP_TO_DATE
+    }
+
+    def "bad incompatible change name is reported"() {
+        when:
+        def result = fails "configuredWithBadCompatibilityChange"
+
+        then:
+        result.task(":configuredWithBadCompatibilityChange").outcome == TaskOutcome.FAILED
+
+        when:
+        result = fails 'configuredWithBadCompatibilityChange'
+
+        then:
+        result.task(":configuredWithBadCompatibilityChange").outcome == TaskOutcome.FAILED
+    }
+}

--- a/src/test/test-projects/incompatible-change-exclusion/build.gradle
+++ b/src/test/test-projects/incompatible-change-exclusion/build.gradle
@@ -1,0 +1,40 @@
+plugins {
+    id 'java'
+    id 'me.champeau.gradle.japicmp'
+}
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    main2
+}
+
+task jarv2(type:Jar) {
+    archiveClassifier = 'v2'
+    from sourceSets.main2.output
+}
+
+task japicmpDetectsNewDefaultMethodByDefault(type: me.champeau.gradle.japicmp.JapicmpTask) {
+    oldClasspath.from(jar)
+    newClasspath.from(jarv2)
+    failOnModification = true
+    failOnSourceIncompatibility = true
+}
+
+task configuredToIgnoreNewDefaultMethod(type: me.champeau.gradle.japicmp.JapicmpTask) {
+    oldClasspath.from(jar)
+    newClasspath.from(jarv2)
+    failOnModification = true
+    failOnSourceIncompatibility = true
+    compatibilityChangeExcludes = [ "METHOD_NEW_DEFAULT" ]
+}
+
+task configuredWithBadCompatibilityChange(type: me.champeau.gradle.japicmp.JapicmpTask) {
+    oldClasspath.from(jar)
+    newClasspath.from(jarv2)
+    failOnModification = true
+    failOnSourceIncompatibility = true
+    compatibilityChangeExcludes = [ "METHOD_NEWISH_DEFAULT" ]
+}

--- a/src/test/test-projects/incompatible-change-exclusion/src/main/java/Interface.java
+++ b/src/test/test-projects/incompatible-change-exclusion/src/main/java/Interface.java
@@ -1,0 +1,7 @@
+package me.champeau.gradle.japicmp;
+
+public interface Interface {
+
+	boolean methodA();
+
+}

--- a/src/test/test-projects/incompatible-change-exclusion/src/main2/java/Interface.java
+++ b/src/test/test-projects/incompatible-change-exclusion/src/main2/java/Interface.java
@@ -1,0 +1,11 @@
+package me.champeau.gradle.japicmp;
+
+public interface Interface {
+
+	boolean methodA();
+
+	default boolean notMethodA() {
+		return !methodA();
+	}
+
+}


### PR DESCRIPTION
This commit adds the compatibilityChangeExcludes configuration option
which allows to simply turn well-known `JApiCompatibilityChange` enum
values into compatible changes, effectively excluding all instances
of such violations from the API comparison.

Fixes #43.
