### PR TITLE
Pass the classpath into japicmp for comparing

### DIFF
--- a/src/main/java/me/champeau/gradle/japicmp/JApiCmpWorkerAction.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JApiCmpWorkerAction.java
@@ -65,6 +65,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class JApiCmpWorkerAction extends JapiCmpWorkerConfiguration implements Runnable {
 
@@ -102,6 +103,8 @@ public class JApiCmpWorkerAction extends JapiCmpWorkerConfiguration implements R
     private JarArchiveComparatorOptions createOptions() {
         JarArchiveComparatorOptions options = new JarArchiveComparatorOptions();
         options.setClassPathMode(JarArchiveComparatorOptions.ClassPathMode.TWO_SEPARATE_CLASSPATHS);
+        options.setOldClassPath(oldClasspath.stream().map(a -> a.file.getAbsolutePath()).collect(Collectors.toList()));
+        options.setNewClassPath(newClasspath.stream().map(a -> a.file.getAbsolutePath()).collect(Collectors.toList()));
         options.setIncludeSynthetic(includeSynthetic);
         options.getIgnoreMissingClasses().setIgnoreAllMissingClasses(ignoreMissingClasses);
         for (String packageInclude : packageIncludes) {

--- a/src/test/groovy/me/champeau/gradle/ClasspathIsUsedFunctionalTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/ClasspathIsUsedFunctionalTest.groovy
@@ -1,0 +1,35 @@
+package me.champeau.gradle
+
+import org.gradle.testkit.runner.TaskOutcome
+
+class ClasspathIsUsedFunctionalTest extends BaseFunctionalTest {
+    String testProject = 'classpath-is-used'
+
+    def "classpath property is passed to japicmp entirely"() {
+        when:
+        def result = run 'japicmp'
+
+        then:
+        result.task(":japicmp").outcome == TaskOutcome.SUCCESS
+        // Superclasses can only be reported if the classpath is present
+        hasTextReport('''
+***! MODIFIED CLASS: PUBLIC me.champeau.gradle.japicmp.Subtype  (not serializable)
+\t===  CLASS FILE FORMAT VERSION: 61.0 <- 61.0
+\t***! MODIFIED SUPERCLASS: me.champeau.gradle.japicmp.ChangedLibrarySuperclass (<- me.champeau.gradle.japicmp.LibrarySuperclass)
+\t===  UNCHANGED CONSTRUCTOR: PUBLIC Subtype()
+''')
+        noHtmlReport()
+        noRichReport()
+    }
+
+    // This is a sanity check to ensure this test is not affected by a future change in how japicmp reports superclasses
+    // Technically japicmp does not need to load the class to check basic superclass compatibility, but it currently does
+    def "setting no classpath property results in a failure"() {
+        when:
+        def result = fails 'japicmpWithoutClasspath'
+
+        then:
+        result.task(":japicmpWithoutClasspath").outcome == TaskOutcome.FAILED
+        result.output.contains("javassist.NotFoundException: me.champeau.gradle.japicmp.LibrarySuperclass")
+    }
+}

--- a/src/test/groovy/me/champeau/gradle/ClasspathIsUsedFunctionalTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/ClasspathIsUsedFunctionalTest.groovy
@@ -14,7 +14,7 @@ class ClasspathIsUsedFunctionalTest extends BaseFunctionalTest {
         // Superclasses can only be reported if the classpath is present
         hasTextReport('''
 ***! MODIFIED CLASS: PUBLIC me.champeau.gradle.japicmp.Subtype  (not serializable)
-\t===  CLASS FILE FORMAT VERSION: 61.0 <- 61.0
+\t===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
 \t***! MODIFIED SUPERCLASS: me.champeau.gradle.japicmp.ChangedLibrarySuperclass (<- me.champeau.gradle.japicmp.LibrarySuperclass)
 \t===  UNCHANGED CONSTRUCTOR: PUBLIC Subtype()
 ''')

--- a/src/test/test-projects/classpath-is-used/build.gradle
+++ b/src/test/test-projects/classpath-is-used/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id 'java'
+    id 'me.champeau.gradle.japicmp'
+}
+
+repositories {
+    mavenCentral()
+}
+
+sourceSets {
+    main2
+}
+
+dependencies {
+    implementation project(":old-library")
+    main2Implementation project(":new-library")
+}
+
+task jarv2(type:Jar) {
+    archiveClassifier = 'v2'
+    from sourceSets.main2.output
+}
+
+task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask) {
+    oldClasspath.from(configurations.runtimeClasspath)
+    newClasspath.from(configurations.main2RuntimeClasspath)
+    oldArchives.from(jar)
+    newArchives.from(jarv2)
+    txtOutputFile = file("$buildDir/reports/japi.txt")
+}
+
+task japicmpWithoutClasspath(type: me.champeau.gradle.japicmp.JapicmpTask) {
+    oldArchives.from(jar)
+    newArchives.from(jarv2)
+    txtOutputFile = file("$buildDir/reports/japi.txt")
+}

--- a/src/test/test-projects/classpath-is-used/new-library/build.gradle
+++ b/src/test/test-projects/classpath-is-used/new-library/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'java'
+}

--- a/src/test/test-projects/classpath-is-used/new-library/src/main/java/ChangedLibrarySuperclass.java
+++ b/src/test/test-projects/classpath-is-used/new-library/src/main/java/ChangedLibrarySuperclass.java
@@ -1,0 +1,4 @@
+package me.champeau.gradle.japicmp;
+
+public class ChangedLibrarySuperclass {
+}

--- a/src/test/test-projects/classpath-is-used/old-library/build.gradle
+++ b/src/test/test-projects/classpath-is-used/old-library/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'java'
+}

--- a/src/test/test-projects/classpath-is-used/old-library/src/main/java/LibrarySuperclass.java
+++ b/src/test/test-projects/classpath-is-used/old-library/src/main/java/LibrarySuperclass.java
@@ -1,0 +1,4 @@
+package me.champeau.gradle.japicmp;
+
+public class LibrarySuperclass {
+}

--- a/src/test/test-projects/classpath-is-used/settings.gradle
+++ b/src/test/test-projects/classpath-is-used/settings.gradle
@@ -1,0 +1,2 @@
+include(":new-library")
+include(":old-library")

--- a/src/test/test-projects/classpath-is-used/src/main/java/Subtype.java
+++ b/src/test/test-projects/classpath-is-used/src/main/java/Subtype.java
@@ -1,0 +1,3 @@
+package me.champeau.gradle.japicmp;
+
+public class Subtype extends LibrarySuperclass {}

--- a/src/test/test-projects/classpath-is-used/src/main2/java/Subtype.java
+++ b/src/test/test-projects/classpath-is-used/src/main2/java/Subtype.java
@@ -1,0 +1,3 @@
+package me.champeau.gradle.japicmp;
+
+public class Subtype extends ChangedLibrarySuperclass {}


### PR DESCRIPTION
Without it, it's impossible to add types to satisfy missing class errors

Drafted while I add tests.