### PR TITLE
Add normalizedArguments as japiCmp task input instead of rule arguments

### DIFF
--- a/src/main/java/me/champeau/gradle/japicmp/report/RichReport.java
+++ b/src/main/java/me/champeau/gradle/japicmp/report/RichReport.java
@@ -10,6 +10,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 
@@ -75,6 +76,10 @@ public abstract class RichReport {
         getRules().add(new ViolationTransformerConfiguration(transformer, params));
     }
 
+    public void addViolationTransformerWithNormalization(Class<? extends ViolationTransformer> transformer, Map<String, String> params, Map<String, String> normalizedParams) {
+        getRules().add(new ViolationTransformerConfiguration(transformer, params, normalizedParams));
+    }
+
     public void renderer(Class<? extends RichReportRenderer> rendererType) {
         this.getRenderer().set(rendererType);
     }
@@ -104,7 +109,7 @@ public abstract class RichReport {
     @Input
     public abstract Property<String> getDescription();
 
-    @Input
+    @Nested
     public abstract ListProperty<RuleConfiguration> getRules();
 
     @Input

--- a/src/main/java/me/champeau/gradle/japicmp/report/RuleConfiguration.java
+++ b/src/main/java/me/champeau/gradle/japicmp/report/RuleConfiguration.java
@@ -15,23 +15,53 @@
  */
 package me.champeau.gradle.japicmp.report;
 
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
+
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 
 public class RuleConfiguration<T> implements Serializable {
+
     protected final Class<? extends T> ruleClass;
     protected final Map<String, String> arguments;
+    protected final Map<String, String> normalizedArguments;
 
     public RuleConfiguration(final Class<? extends T> ruleClass, final Map<String, String> arguments) {
         this.ruleClass = ruleClass;
         this.arguments = arguments;
+        this.normalizedArguments = null;
     }
 
+    public RuleConfiguration(final Class<? extends T> ruleClass, final Map<String, String> arguments, final Map<String, String> normalizedArguments) {
+        this.ruleClass = ruleClass;
+        this.arguments = arguments;
+        this.normalizedArguments = normalizedArguments;
+    }
+
+    @Input
     public Class<? extends T> getRuleClass() {
         return ruleClass;
     }
 
+    @Internal
     public Map<String, String> getArguments() {
         return arguments;
     }
+
+    @Input
+    @Optional
+    public Map<String, String> getNormalizedArguments() {
+        Map<String, String> mergedArguments = new HashMap<>();
+        if(null != arguments) {
+            mergedArguments.putAll(arguments);
+        }
+        if(null != normalizedArguments) {
+            mergedArguments.putAll(normalizedArguments);
+        }
+        return mergedArguments;
+    }
+
 }

--- a/src/main/java/me/champeau/gradle/japicmp/report/ViolationTransformerConfiguration.java
+++ b/src/main/java/me/champeau/gradle/japicmp/report/ViolationTransformerConfiguration.java
@@ -21,4 +21,17 @@ public class ViolationTransformerConfiguration extends RuleConfiguration<Violati
     public ViolationTransformerConfiguration(Class<? extends ViolationTransformer> ruleClass, Map<String, String> arguments) {
         super(ruleClass, arguments);
     }
+
+    /**
+     * This constructor allows to override entries in the {@code japiCmp.richReport.rules } collection exposed by {@link RuleConfiguration#getNormalizedArguments()} } () getNormalizedArguments()}.
+     * Although {@link RuleConfiguration#getArguments()} getArguments()} } collection contains the rule arguments, {@link RuleConfiguration#getNormalizedArguments()} } () getNormalizedArguments()} is the collection used as Gradle task input.
+     * This allows to apply some normalization when inputs are volatile (ie. absolute paths in rule).
+     *
+     * @param ruleClass rule class
+     * @param arguments rule arguments
+     * @param normalizedArguments normalized rule arguments
+     */
+    public ViolationTransformerConfiguration(Class<? extends ViolationTransformer> ruleClass, Map<String, String> arguments, Map<String, String> normalizedArguments) {
+        super(ruleClass, arguments, normalizedArguments);
+    }
 }


### PR DESCRIPTION
### Issue
the `japiCmpTask` is not [relocatable](https://docs.gradle.org/current/userguide/build_cache_debugging.html#caching_relocation_test) when using rule arguments with absolute paths.
[Here is an example](https://github.com/micronaut-projects/micronaut-build/blob/ffc0dfd6c8e4b099d1281b47a9853a7a497164ab/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java#L104) in the `micronaut-build` project.

**The cost of this with a relocated build is 1mn23s** on the `micronaut-core` build
![Screenshot 2023-08-25 at 9 34 37 AM](https://github.com/melix/japicmp-gradle-plugin/assets/10243934/a6110fd0-4cd3-4512-b338-d918ad5d1793)

Here is the build scan comparison illustrating the volatile inputs
![Screenshot 2023-08-25 at 9 34 10 AM](https://github.com/melix/japicmp-gradle-plugin/assets/10243934/693ac8c6-0c58-4cc0-bb3a-73b3aa114019)

### Fix
This PR adds a rule constructor which allow to add a normalized version of the arguments which will be used as rule inputs.
The consumer would then call this constructor with normalized are arguments, here is how [in the micronaut-build](https://github.com/micronaut-projects/micronaut-build/blob/ffc0dfd6c8e4b099d1281b47a9853a7a497164ab/src/main/groovy/io/micronaut/build/compat/MicronautBinaryCompatibilityPlugin.java#L104):
```
report.addViolationTransformerWithNormalization(AcceptedApiChangesRule.class,
                                    Collections.singletonMap(AcceptedApiChangesRule.CHANGES_FILE, changesFile.getAbsolutePath()),
                                    Collections.singletonMap(AcceptedApiChangesRule.CHANGES_FILE, project.relativePath(changesFile.getAbsolutePath()))
)

```
### Question
This PR only addresses the `ViolationTransformer` rule type, do all subtypes of `RuleConfiguration` have to be addressed the same way?
