### PR TITLE
Upgrade to JApiCmp 0.22.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildScanRecipes {
 }
 
 dependencies {
-    api("com.github.siom79.japicmp:japicmp:0.18.3") {
+    api("com.github.siom79.japicmp:japicmp:0.22.0") {
         exclude(group = "com.google.guava")
         exclude(group = "io.airlift")
         exclude(group = "javax.xml.bind")
@@ -21,5 +21,5 @@ dependencies {
     compileOnly(gradleApi())
 
     testImplementation(gradleTestKit())
-    testImplementation("org.spockframework:spock-core:2.1-groovy-3.0")
+    testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
 }

--- a/src/main/java/me/champeau/gradle/japicmp/report/CompatibilityChangeViolationRuleConfiguration.java
+++ b/src/main/java/me/champeau/gradle/japicmp/report/CompatibilityChangeViolationRuleConfiguration.java
@@ -15,19 +15,19 @@
  */
 package me.champeau.gradle.japicmp.report;
 
-import japicmp.model.JApiCompatibilityChange;
+import japicmp.model.JApiCompatibilityChangeType;
 
 import java.util.Map;
 
 public class CompatibilityChangeViolationRuleConfiguration extends ViolationRuleConfiguration {
-    private final JApiCompatibilityChange change;
+    private final JApiCompatibilityChangeType change;
 
-    public CompatibilityChangeViolationRuleConfiguration(final Class<? extends ViolationRule> ruleClass, final Map<String, String> arguments, final JApiCompatibilityChange change) {
+    public CompatibilityChangeViolationRuleConfiguration(final Class<? extends ViolationRule> ruleClass, final Map<String, String> arguments, final JApiCompatibilityChangeType change) {
         super(ruleClass, arguments);
         this.change = change;
     }
 
-    public JApiCompatibilityChange getChange() {
+    public JApiCompatibilityChangeType getChange() {
         return change;
     }
 }

--- a/src/main/java/me/champeau/gradle/japicmp/report/RichReport.java
+++ b/src/main/java/me/champeau/gradle/japicmp/report/RichReport.java
@@ -1,7 +1,7 @@
 package me.champeau.gradle.japicmp.report;
 
 import japicmp.model.JApiChangeStatus;
-import japicmp.model.JApiCompatibilityChange;
+import japicmp.model.JApiCompatibilityChangeType;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
@@ -51,11 +51,11 @@ public abstract class RichReport {
         addPostProcessRule(rule, null);
     }
 
-    public void addRule(JApiCompatibilityChange change, Class<? extends ViolationRule> rule, Map<String, String> params) {
+    public void addRule(JApiCompatibilityChangeType change, Class<? extends ViolationRule> rule, Map<String, String> params) {
         getRules().add(new CompatibilityChangeViolationRuleConfiguration(rule, params, change));
     }
 
-    public void addRule(JApiCompatibilityChange change, Class<? extends ViolationRule> rule) {
+    public void addRule(JApiCompatibilityChangeType change, Class<? extends ViolationRule> rule) {
         addRule(change, rule, null);
     }
 

--- a/src/main/java/me/champeau/gradle/japicmp/report/Violation.java
+++ b/src/main/java/me/champeau/gradle/japicmp/report/Violation.java
@@ -21,6 +21,7 @@ import japicmp.model.JApiAnnotationElement;
 import japicmp.model.JApiClass;
 import japicmp.model.JApiCompatibility;
 import japicmp.model.JApiCompatibilityChange;
+import japicmp.model.JApiCompatibilityChangeType;
 import japicmp.model.JApiConstructor;
 import japicmp.model.JApiField;
 import japicmp.model.JApiImplementedInterface;
@@ -91,7 +92,7 @@ public class Violation {
         }
         List<String> describedChanges = new ArrayList<String>(changes.size());
         for (JApiCompatibilityChange change : changes) {
-            describedChanges.add(describe(change));
+            describedChanges.add(describe(change.getType()));
         }
         return describedChanges;
     }
@@ -140,7 +141,7 @@ public class Violation {
         return member.toString();
     }
 
-    public static String describe(JApiCompatibilityChange change) {
+    public static String describe(JApiCompatibilityChangeType change) {
         switch (change) {
             case ANNOTATION_DEPRECATED_ADDED:
                 return "Deprecated annotation was added";

--- a/src/main/java/me/champeau/gradle/japicmp/report/ViolationsGenerator.java
+++ b/src/main/java/me/champeau/gradle/japicmp/report/ViolationsGenerator.java
@@ -19,6 +19,7 @@ import japicmp.model.JApiChangeStatus;
 import japicmp.model.JApiClass;
 import japicmp.model.JApiCompatibility;
 import japicmp.model.JApiCompatibilityChange;
+import japicmp.model.JApiCompatibilityChangeType;
 import japicmp.model.JApiConstructor;
 import japicmp.model.JApiField;
 import japicmp.model.JApiHasChangeStatus;
@@ -41,7 +42,7 @@ import java.util.regex.Pattern;
 public class ViolationsGenerator {
     private final List<Pattern> includePatterns;
     private final List<Pattern> excludePatterns;
-    private final Map<JApiCompatibilityChange, List<ViolationRule>> apiCompatibilityRules = new HashMap<JApiCompatibilityChange, List<ViolationRule>>();
+    private final Map<JApiCompatibilityChangeType, List<ViolationRule>> apiCompatibilityRules = new HashMap<JApiCompatibilityChangeType, List<ViolationRule>>();
     private final Map<JApiChangeStatus, List<ViolationRule>> statusRules = new HashMap<JApiChangeStatus, List<ViolationRule>>();
     private final List<ViolationRule> genericRules = new ArrayList<ViolationRule>();
 
@@ -86,7 +87,7 @@ public class ViolationsGenerator {
         genericRules.add(rule);
     }
 
-    public void addRule(JApiCompatibilityChange change, ViolationRule rule) {
+    public void addRule(JApiCompatibilityChangeType change, ViolationRule rule) {
         List<ViolationRule> violationRules = apiCompatibilityRules.get(change);
         if (violationRules == null) {
             violationRules = new ArrayList<>();
@@ -181,7 +182,7 @@ public class ViolationsGenerator {
         processClass(clazz, context);
     }
 
-    private void processCompatibilityChange(JApiCompatibilityChange kind, JApiCompatibility member, final Context context) {
+    private void processCompatibilityChange(JApiCompatibilityChangeType kind, JApiCompatibility member, final Context context) {
         List<ViolationRule> violationRules = apiCompatibilityRules.get(kind);
         if (violationRules != null) {
             for (ViolationRule violationRule : violationRules) {
@@ -220,7 +221,7 @@ public class ViolationsGenerator {
 
     private void processCompatibilityChanges(final JApiCompatibility elt, final Context context) {
         for (JApiCompatibilityChange compatibilityChange : elt.getCompatibilityChanges()) {
-            processCompatibilityChange(compatibilityChange, elt, context);
+            processCompatibilityChange(compatibilityChange.getType(), elt, context);
         }
     }
 

--- a/src/test/groovy/me/champeau/gradle/ReportsFunctionalTest.groovy
+++ b/src/test/groovy/me/champeau/gradle/ReportsFunctionalTest.groovy
@@ -11,8 +11,16 @@ class ReportsFunctionalTest extends BaseFunctionalTest {
 
         then:
         result.task(":japicmp").outcome == TaskOutcome.SUCCESS
-        hasHtmlReport('<td>Old:</td><td>commons-lang3-3.5.jar</td>')
-        hasHtmlReport('<td>New:</td><td>commons-lang3-3.6.jar</td>')
+        hasHtmlReport("""
+\t\t\t<td>Old:</td>
+\t\t\t<td>
+\t\t\t\tcommons-lang3-3.5.jar
+\t\t\t</td>""")
+        hasHtmlReport("""
+\t\t\t<td>New:</td>
+\t\t\t<td>
+\t\t\t\tcommons-lang3-3.6.jar
+\t\t\t</td>""")
         hasHtmlReport('<a href="#org.apache.commons.lang3.event.EventListenerSupport">')
         noTxtReport()
         noSemverReport()

--- a/src/test/test-projects/rich-report/build.gradle
+++ b/src/test/test-projects/rich-report/build.gradle
@@ -1,7 +1,7 @@
 import japicmp.model.JApiChangeStatus
 import japicmp.model.JApiClass
 import japicmp.model.JApiCompatibility
-import japicmp.model.JApiCompatibilityChange
+import japicmp.model.JApiCompatibilityChangeType
 import me.champeau.gradle.japicmp.report.AbstractContextAwareViolationRule
 import me.champeau.gradle.japicmp.report.PostProcessViolationsRule
 import me.champeau.gradle.japicmp.report.SetupRule
@@ -67,7 +67,7 @@ task japicmpChange(type: me.champeau.gradle.japicmp.JapicmpTask) {
     richReport {
         reportName = 'rich.html'
         description = 'A test of rich report'
-        addRule(JApiCompatibilityChange.CLASS_NO_LONGER_PUBLIC, GenericRule)
+        addRule(JApiCompatibilityChangeType.CLASS_NO_LONGER_PUBLIC, GenericRule)
         addSetupRule(MySetupRule)
         addPostProcessRule(MyTearDownRule)
         addRule(ContextAwareRule)


### PR DESCRIPTION
Upgrade to the latest JApiCmp version. This required some minor refactoring to account for changes in the way html reports are generated, and the fact that `JApiCompatibilityChange` change type enumerations were moved to `JApiCompatibilityChangeType`.