### PR TITLE
Add release and snapshot workflows on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,22 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
       - name: Build
         run: ./gradlew build "-Pme.champeau.japicmp.javaToolchain.test=${{ matrix.jdk }}"
+
+  publish-snapshot:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'melix' && github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
+      # Disable CC due to https://github.com/gradle/gradle/issues/22779
+      - run: ./gradlew publish --no-configuration-cache
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USER }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: ${{ matrix.jdk }}
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - name: Build
         run: ./gradlew build "-Pme.champeau.japicmp.javaToolchain.test=${{ matrix.jdk }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'melix'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
+      # Disable CC due to https://github.com/gradle/gradle/issues/22779
+      - run: ./gradlew publish publishPlugins --no-configuration-cache
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_SECRET }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USER }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_KEY_PASSWORD }}
+      - name: Create release
+        run: |
+          # Extract version from tag, e.g. RELEASE_1_2_3 -> 1.2.3
+          version=$(echo ${{ github.ref_name }} | sed -E 's/RELEASE_([0-9]+)_([0-9]+)_([0-9]+)/\1.\2.\3/')
+          echo "$version"
+          
+          gh release create ${{ github.ref_name }} --title "$version" --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -6,3 +6,8 @@ repositories {
    mavenCentral()
    gradlePluginPortal()
 }
+
+dependencies {
+   implementation("com.gradle.publish:plugin-publish-plugin:1.2.1")
+   implementation("com.vanniktech:gradle-maven-publish-plugin:0.29.0")
+}

--- a/build-logic/src/main/kotlin/me.champeau.convention-testing.gradle.kts
+++ b/build-logic/src/main/kotlin/me.champeau.convention-testing.gradle.kts
@@ -6,6 +6,7 @@ val isCiBuild = providers.environmentVariable("CI").isPresent
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+    inputs.dir("src/test/test-projects").withPropertyName("testProjects")
 
     maxParallelForks = if (isCiBuild) {
         Runtime.getRuntime().availableProcessors()

--- a/build-logic/src/main/kotlin/me.champeau.convention.gradle.kts
+++ b/build-logic/src/main/kotlin/me.champeau.convention.gradle.kts
@@ -15,10 +15,6 @@ java {
     withJavadocJar()
 }
 
-tasks.test {
-    inputs.dir("src/test/test-projects").withPropertyName("testProjects")
-}
-
 gradlePlugin {
     website = providers.gradleProperty("POM_URL")
     vcsUrl = providers.gradleProperty("POM_URL")

--- a/build-logic/src/main/kotlin/me.champeau.convention.gradle.kts
+++ b/build-logic/src/main/kotlin/me.champeau.convention.gradle.kts
@@ -1,8 +1,12 @@
 plugins {
-    id("groovy-gradle-plugin")
-    id("maven-publish")
-    id("signing")
+    `java-gradle-plugin`
+    id("com.gradle.plugin-publish")
+    id("com.vanniktech.maven.publish")
 }
+
+version = providers.gradleProperty("VERSION_NAME").get()
+group = providers.gradleProperty("GROUP").get()
+description = providers.gradleProperty("POM_DESCRIPTION").get()
 
 java {
     toolchain {
@@ -12,37 +16,21 @@ java {
     withJavadocJar()
 }
 
-tasks.named("test") {
+tasks.test {
     inputs.dir("src/test/test-projects").withPropertyName("testProjects")
 }
 
 gradlePlugin {
-    website = "https://github.com/melix/japicmp-gradle-plugin"
-    vcsUrl = "https://github.com/melix/japicmp-gradle-plugin"
+    website = providers.gradleProperty("POM_URL")
+    vcsUrl = providers.gradleProperty("POM_URL")
 
     plugins {
         create("japicmpPlugin") {
             id = "me.champeau.gradle.japicmp"
             implementationClass = "me.champeau.gradle.japicmp.JapicmpPlugin"
-            displayName = "Gradle Plugin for JApicmp"
-            description = "Gradle Plugin for JApicmp"
+            displayName = providers.gradleProperty("POM_NAME").get()
+            description = providers.gradleProperty("POM_DESCRIPTION").get()
             tags = listOf("jacpicmp")
         }
-    }
-}
-
-publishing {
-    repositories {
-        maven {
-            name = "build"
-            setUrl(layout.buildDirectory.file("repo").get().asFile.path)
-        }
-    }
-}
-
-signing {
-    useGpgCmd()
-    publishing.publications.forEach { pub ->
-        sign(pub)
     }
 }

--- a/build-logic/src/main/kotlin/me.champeau.convention.gradle.kts
+++ b/build-logic/src/main/kotlin/me.champeau.convention.gradle.kts
@@ -9,9 +9,8 @@ group = providers.gradleProperty("GROUP").get()
 description = providers.gradleProperty("POM_DESCRIPTION").get()
 
 java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
-    }
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
     withSourcesJar()
     withJavadocJar()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,28 @@
-group=me.champeau.gradle
-version=0.4.4-SNAPSHOT
-
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
+
+
+GROUP=me.champeau.gradle
+POM_ARTIFACT_ID=japicmp-gradle-plugin
+VERSION_NAME=0.4.4-SNAPSHOT
+
+SONATYPE_AUTOMATIC_RELEASE=true
+SONATYPE_HOST=DEFAULT
+RELEASE_SIGNING_ENABLED=true
+
+POM_NAME=Gradle Plugin for JApicmp
+POM_DESCRIPTION=The japicmp-gradle-plugin provides binary compatibility reporting through JApicmp using Gradle.
+POM_URL=https://github.com/melix/japicmp-gradle-plugin
+
+POM_LICENSE_NAME=The Apache Software License, Version 2.0
+POM_LICENSE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENSE_DIST=repo
+
+POM_SCM_URL=https://github.com/melix/japicmp-gradle-plugin
+POM_SCM_CONNECTION=scm:git:git://github.com/melix/japicmp-gradle-plugin.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/melix/japicmp-gradle-plugin.git
+
+POM_DEVELOPER_ID=melix
+POM_DEVELOPER_NAME=Cédric Champeau
+POM_DEVELOPER_URL=https://melix.github.io/blog


### PR DESCRIPTION
```
tree .m2/repository/me/champeau/gradle/

.m2/repository/me/champeau/gradle/
├── japicmp
│   └── me.champeau.gradle.japicmp.gradle.plugin
│       ├── 0.4.4-SNAPSHOT
│       │   ├── maven-metadata-local.xml
│       │   ├── me.champeau.gradle.japicmp.gradle.plugin-0.4.4-SNAPSHOT.pom
│       │   └── me.champeau.gradle.japicmp.gradle.plugin-0.4.4-SNAPSHOT.pom.asc
│       └── maven-metadata-local.xml
└── japicmp-gradle-plugin
    ├── 0.4.4-SNAPSHOT
    │   ├── japicmp-gradle-plugin-0.4.4-SNAPSHOT-javadoc.jar
    │   ├── japicmp-gradle-plugin-0.4.4-SNAPSHOT-javadoc.jar.asc
    │   ├── japicmp-gradle-plugin-0.4.4-SNAPSHOT-sources.jar
    │   ├── japicmp-gradle-plugin-0.4.4-SNAPSHOT-sources.jar.asc
    │   ├── japicmp-gradle-plugin-0.4.4-SNAPSHOT.jar
    │   ├── japicmp-gradle-plugin-0.4.4-SNAPSHOT.jar.asc
    │   ├── japicmp-gradle-plugin-0.4.4-SNAPSHOT.module
    │   ├── japicmp-gradle-plugin-0.4.4-SNAPSHOT.module.asc
    │   ├── japicmp-gradle-plugin-0.4.4-SNAPSHOT.pom
    │   ├── japicmp-gradle-plugin-0.4.4-SNAPSHOT.pom.asc
    │   └── maven-metadata-local.xml
    └── maven-metadata-local.xml

6 directories, 16 files


cat .m2/repository/me/champeau/gradle/japicmp-gradle-plugin/0.4.4-SNAPSHOT/japicmp-gra
dle-plugin-0.4.4-SNAPSHOT.pom

<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <!-- This module was also published with a richer model, Gradle metadata,  -->
  <!-- which should be used instead. Do not delete the following line which  -->
  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
  <!-- that they should prefer consuming it instead. -->
  <!-- do_not_remove: published-with-gradle-metadata -->
  <modelVersion>4.0.0</modelVersion>
  <groupId>me.champeau.gradle</groupId>
  <artifactId>japicmp-gradle-plugin</artifactId>
  <version>0.4.4-SNAPSHOT</version>
  <name>Gradle Plugin for JApicmp</name>
  <description>The japicmp-gradle-plugin provides binary compatibility reporting through JApicmp using Gradle.</description>
  <url>https://github.com/melix/japicmp-gradle-plugin</url>
  <licenses>
    <license>
      <name>The Apache Software License, Version 2.0</name>
      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
  <developers>
    <developer>
      <id>melix</id>
      <name>Cédric Champeau</name>
      <url>https://melix.github.io/blog</url>
    </developer>
  </developers>
  <scm>
    <connection>scm:git:git://github.com/melix/japicmp-gradle-plugin.git</connection>
    <developerConnection>scm:git:ssh://git@github.com/melix/japicmp-gradle-plugin.git</developerConnection>
    <url>https://github.com/melix/japicmp-gradle-plugin</url>
  </scm>
  <dependencies>
    <dependency>
      <groupId>com.github.siom79.japicmp</groupId>
      <artifactId>japicmp</artifactId>
      <version>0.23.0</version>
      <scope>compile</scope>
      <exclusions>
        <exclusion>
          <groupId>com.sun.xml.bind</groupId>
          <artifactId>*</artifactId>
        </exclusion>
        <exclusion>
          <groupId>com.google.guava</groupId>
          <artifactId>*</artifactId>
        </exclusion>
        <exclusion>
          <groupId>javax.xml.bind</groupId>
          <artifactId>*</artifactId>
        </exclusion>
        <exclusion>
          <groupId>io.airlift</groupId>
          <artifactId>*</artifactId>
        </exclusion>
      </exclusions>
    </dependency>
  </dependencies>
</project>
```