### PR TITLE
Changed exception on hasBreakingChange to VerificationException

### DIFF
--- a/src/main/java/me/champeau/gradle/japicmp/JApiCmpWorkerAction.java
+++ b/src/main/java/me/champeau/gradle/japicmp/JApiCmpWorkerAction.java
@@ -59,6 +59,7 @@ import me.champeau.gradle.japicmp.report.ViolationTransformer;
 import me.champeau.gradle.japicmp.report.ViolationTransformerConfiguration;
 import me.champeau.gradle.japicmp.report.ViolationsGenerator;
 import org.gradle.api.GradleException;
+import org.gradle.api.tasks.VerificationException;
 
 import javax.inject.Inject;
 import java.io.BufferedWriter;
@@ -373,7 +374,7 @@ public class JApiCmpWorkerAction extends JapiCmpWorkerConfiguration implements R
             } catch (URISyntaxException e) {
                 reportLink = null;
             }
-            StringBuilder message = new StringBuilder("Detected binary changes.\n")
+            StringBuilder message = new StringBuilder("Verification failed: Detected binary changes.\n")
                     .append("    - current: ")
                     .append(prettyPrint(current))
                     .append("\n    - baseline: ")
@@ -382,7 +383,7 @@ public class JApiCmpWorkerAction extends JapiCmpWorkerConfiguration implements R
                 message.append(".").append(System.lineSeparator()).append(System.lineSeparator());
                 message.append("See failure report at ").append(reportLink);
             }
-            throw new GradleException(message.toString());
+            throw new VerificationException(message.toString());
         }
     }
 


### PR DESCRIPTION
This change is required for failures coming from the `japicmp-gradle-plugin` to be correctly classified as verification failures when they happen due to detected binary changes.